### PR TITLE
Allow addons to register classes to be instantiated

### DIFF
--- a/documentation/docs/changelog.md
+++ b/documentation/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2024.mm.dd - version 0.0.6-alpha
+
+* Add the Factory:addClass() method
+
 ## 2024.03.08 - version 0.0.5-alpha
 
 * Add the Target facade

--- a/documentation/docs/changelog.md
+++ b/documentation/docs/changelog.md
@@ -2,6 +2,7 @@
 
 ## 2024.mm.dd - version 0.0.6-alpha
 
+* Add the Str support class
 * Allow addons to register
 
 ## 2024.03.08 - version 0.0.5-alpha

--- a/documentation/docs/changelog.md
+++ b/documentation/docs/changelog.md
@@ -2,7 +2,7 @@
 
 ## 2024.mm.dd - version 0.0.6-alpha
 
-* Add the Factory:addClass() method
+* Allow addons to register
 
 ## 2024.03.08 - version 0.0.5-alpha
 

--- a/documentation/docs/resources/core/factory.md
+++ b/documentation/docs/resources/core/factory.md
@@ -10,7 +10,7 @@ that are registered in its `classes` property.
 These are the steps to allow classes to be instantiated:
 
 1. When writing a Lua file containing a class, make sure to register it by doing
-`self.classes['<class name>'] = <class name>` right below the `<class name>.__index = <class name>`
+`self:addClass('<class name>', <class name>)` right below the `<class name>.__index = <class name>`
 line
 1. Write the `__constructor()` method accepting zero or many parameters
 
@@ -23,7 +23,7 @@ Example:
 ```lua
 local MyClass = {}
 MyClass.__index = MyClass
-self.classes['MyClass'] = MyClass
+self:addClass('MyClass', MyClass)
 
 function MyClass.__construct(name)
     local self = setmetatable({}, MyClass)

--- a/documentation/docs/resources/facades/_category_.json
+++ b/documentation/docs/resources/facades/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "Facades",
+  "link": {
+    "type": "generated-index",
+    "description": "Facades to ease the connection between addons and the World of Warcraft API."
+  }
+}

--- a/documentation/docs/resources/support/arr.md
+++ b/documentation/docs/resources/support/arr.md
@@ -65,6 +65,7 @@ reaching the last key.
 * `Arr:get()` - Gets a value in an array using the dot notation.
 * `Arr:implode()` - Combines the elements of a table into a single string,
 separated by a specified delimiter.
+* `Arr:inArray()` - Determines whether a value is in an array.
 * `Arr:isArray()` - Determines whether the value is an array indexed by numeric keys or not, by returning false if the table has string keys
 * `Arr:map()` - Iterates over the list values and calls the callback
 function in the second argument for each of them.

--- a/documentation/docs/resources/support/arr.md
+++ b/documentation/docs/resources/support/arr.md
@@ -66,6 +66,8 @@ reaching the last key.
 * `Arr:implode()` - Combines the elements of a table into a single string,
 separated by a specified delimiter.
 * `Arr:isArray()` - Determines whether the value is an array indexed by numeric keys or not, by returning false if the table has string keys
+* `Arr:map()` - Iterates over the list values and calls the callback
+function in the second argument for each of them.
 * `Arr:maybeInitialize()` - Initializes a value in a table if it's not 
 initialized yet.
 * `Arr:set()` - Sets a value in an array using the dot notation.

--- a/documentation/docs/resources/support/arr.md
+++ b/documentation/docs/resources/support/arr.md
@@ -66,6 +66,8 @@ reaching the last key.
 * `Arr:implode()` - Combines the elements of a table into a single string,
 separated by a specified delimiter.
 * `Arr:isArray()` - Determines whether the value is an array indexed by numeric keys or not, by returning false if the table has string keys
+* `Arr:maybeInitialize()` - Initializes a value in a table if it's not 
+initialized yet.
 * `Arr:set()` - Sets a value in an array using the dot notation.
 
 :::tip Methods args and logic

--- a/documentation/docs/resources/support/arr.md
+++ b/documentation/docs/resources/support/arr.md
@@ -2,6 +2,76 @@
 
 The **Arr** methods are focused on manipulating arrays.
 
-Each helper method is well documented in the support source code and won't
-be duplicated here. Please, refer to the `./src/Support/Arr.lua` for better
-reference.
+This class was inspired by the PHP Laravel's class and attempts to provide
+similar resources to work with arrays. Of course, Lua tables and PHP arrays
+are different things, but from a development standpoint, they can work 
+similarly.
+
+**Arr** methods are tested by `tests\Support\ArrTest.lua`.
+
+## Dot notation keys
+
+Some **Arr** methods accept dot notation keys, which are keys condensed in 
+a string that are interpreted as nested keys. In World of Warcraft, addon 
+data is usually stored in tables that and their values are retrieved from 
+nested tables.
+
+The dot notation comes in handy to improve readness and also avoid 
+repetitive loops.
+
+Here's an example of how dot notation keys work. Imagine a list created 
+with the following nested lists:
+
+```lua
+local list = {}
+list['root'] = {}
+
+list['root']['level1-a'] = {}
+list['root']['level1-b'] = {}
+list['root']['level1-c'] = {}
+
+list['root']['level1-a']['level2'] = 'some-value'
+```
+
+In order to get the last level value, a `list['root']['level1-a']['level2']`
+call is made, that could also throw errors if any of the indexes don't 
+exist.
+
+With `Arr:get()` it's possible to run:
+
+```lua
+local value = Arr:get(list, 'root.level1-a.level2', 'default-value')
+```
+
+The code above will return the nested value **OR** the default value passed 
+as the third argument. If no default value is provided, `nil` will be 
+returned, but the most important thing here is that no errors will be throw
+by accessing invalid properties inside a table.
+
+On the other hand, `Arr:set()` can create those levels with a single line, 
+with no need to iterate over the table and create the indexes that aren't
+created yet.
+
+```lua
+Arr:set(list, 'root.level1-b.level2', 'another-value')
+```
+
+The code above is the same as doing `list['root']['level1-b']['level2']`,
+however, if `root` or `level1-b` are `nil`, they'll be created as `{}` until
+reaching the last key.
+
+## Methods
+
+* `Arr:get()` - Gets a value in an array using the dot notation.
+* `Arr:implode()` - Combines the elements of a table into a single string,
+separated by a specified delimiter.
+* `Arr:isArray()` - Determines whether the value is an array indexed by numeric keys or not, by returning false if the table has string keys
+* `Arr:set()` - Sets a value in an array using the dot notation.
+
+:::tip Methods args and logic
+
+For more information about valid input for the methods above, please refer
+to the `Arr.lua` file itself as it contains a brief explanation over every
+method for parameters and the logic behind them.
+
+:::

--- a/documentation/docs/resources/support/arr.md
+++ b/documentation/docs/resources/support/arr.md
@@ -74,6 +74,8 @@ numeric keys or not, by returning false if the table has string keys
 function in the second argument for each of them.
 * `Arr:maybeInitialize()` - Initializes a value in a table if it's not 
 initialized yet.
+* `Arr:pluck()` - Extracts a list of values from a list of objects based on 
+a given key.
 * `Arr:set()` - Sets a value in an array using the dot notation.
 
 :::tip Methods args and logic

--- a/documentation/docs/resources/support/arr.md
+++ b/documentation/docs/resources/support/arr.md
@@ -66,7 +66,10 @@ reaching the last key.
 * `Arr:implode()` - Combines the elements of a table into a single string,
 separated by a specified delimiter.
 * `Arr:inArray()` - Determines whether a value is in an array.
-* `Arr:isArray()` - Determines whether the value is an array indexed by numeric keys or not, by returning false if the table has string keys
+* `Arr:insertNotInArray()` - Inserts a value in an array if it's not in the 
+array yet.
+* `Arr:isArray()` - Determines whether the value is an array indexed by 
+numeric keys or not, by returning false if the table has string keys
 * `Arr:map()` - Iterates over the list values and calls the callback
 function in the second argument for each of them.
 * `Arr:maybeInitialize()` - Initializes a value in a table if it's not 

--- a/documentation/docs/resources/support/arr.md
+++ b/documentation/docs/resources/support/arr.md
@@ -76,6 +76,7 @@ function in the second argument for each of them.
 initialized yet.
 * `Arr:pluck()` - Extracts a list of values from a list of objects based on 
 a given key.
+* `Arr:remove()` - Removes a value from an indexed array.
 * `Arr:set()` - Sets a value in an array using the dot notation.
 
 :::tip Methods args and logic

--- a/documentation/docs/resources/support/str.md
+++ b/documentation/docs/resources/support/str.md
@@ -1,0 +1,7 @@
+# Str
+
+The **Str** methods are focused on manipulating strings.
+
+Each helper method is well documented in the support source code and won't
+be duplicated here. Please, refer to the `./src/Support/Src.lua` for better
+reference.

--- a/src/Core/Factory.lua
+++ b/src/Core/Factory.lua
@@ -4,6 +4,15 @@ Contains a list of classes that can be instantiated by the library.
 self.classes = {}
 
 --[[
+Registers a class so the library is able to instantiate it later.
+
+This method's the same as updating self.classes.
+]]
+function self:addClass(classname, classStructure)
+    self.classes[classname] = classStructure
+end
+
+--[[
 This method emulates the new keyword in OOP languages by instantiating a
 class by its name as long as the class has a __construct() method with or
 without parameters.

--- a/src/Facades/Target.lua
+++ b/src/Facades/Target.lua
@@ -6,29 +6,29 @@ This class can also be used to access the target with many other purposes,
 like setting the target icon.
 ]]
 local Target = {
-        -- constants
-        MARKER_REMOVE = 'remove',
-        MARKER_STAR = 'star',
-        MARKER_CIRCLE = 'circle',
-        MARKER_DIAMOND = 'diamond',
-        MARKER_TRIANGLE = 'triangle',
-        MARKER_MOON = 'moon',
-        MARKER_SQUARE = 'square',
-        MARKER_X = 'x',
-        MARKER_SKULL = 'skull',
+    -- constants
+    MARKER_REMOVE = 'remove',
+    MARKER_STAR = 'star',
+    MARKER_CIRCLE = 'circle',
+    MARKER_DIAMOND = 'diamond',
+    MARKER_TRIANGLE = 'triangle',
+    MARKER_MOON = 'moon',
+    MARKER_SQUARE = 'square',
+    MARKER_X = 'x',
+    MARKER_SKULL = 'skull',
 
-        -- markers dictionary
-        markers = {
-            remove   = 0,
-            star     = 1,
-            circle   = 2,
-            diamond  = 3,
-            triangle = 4,
-            moon     = 5,
-            square   = 6,
-            x        = 7,
-            skull    = 8,
-        }
+    -- markers dictionary
+    markers = {
+        remove   = 0,
+        star     = 1,
+        circle   = 2,
+        diamond  = 3,
+        triangle = 4,
+        moon     = 5,
+        square   = 6,
+        x        = 7,
+        skull    = 8,
+    }
     }
     Target.__index = Target
     Target.__ = self

--- a/src/Facades/Target.lua
+++ b/src/Facades/Target.lua
@@ -5,142 +5,183 @@ World of Warcraft API target related methods.
 This class can also be used to access the target with many other purposes,
 like setting the target icon.
 ]]
+local Target = {
+        -- constants
+        MARKER_REMOVE = 'remove',
+        MARKER_STAR = 'star',
+        MARKER_CIRCLE = 'circle',
+        MARKER_DIAMOND = 'diamond',
+        MARKER_TRIANGLE = 'triangle',
+        MARKER_MOON = 'moon',
+        MARKER_SQUARE = 'square',
+        MARKER_X = 'x',
+        MARKER_SKULL = 'skull',
 
-local Target = {}
-Target.__index = Target
+        -- markers dictionary
+        markers = {
+            remove   = 0,
+            star     = 1,
+            circle   = 2,
+            diamond  = 3,
+            triangle = 4,
+            moon     = 5,
+            square   = 6,
+            x        = 7,
+            skull    = 8,
+        }
+    }
+    Target.__index = Target
+    Target.__ = self
 
---[[
-Target constructor.
-]]
-function Target.__construct()
-    local self = setmetatable({}, Target)
-
-    return self
-end
-
---[[
-Gets the target GUID.
-]]
-function Target:getGuid()
-    return UnitGUID('target')
-end
-
---[[
-Gets the target health.
-
-In the World of Warcraft API, the UnitHealth('target') function behaves
-differently for NPCs and other players. For NPCs, it returns the absolute
-value of their health, whereas for players, it returns a value between
-0 and 100 representing the percentage of their current health compared
-to their total health.
-]]
-function Target:getHealth()
-    return self:hasTarget() and UnitHealth('target') or nil
-end
-
---[[
-Gets the target health in percentage.
-
-This method returns a value between 0 and 1, representing the target's
-health percentage.
-]]
-function Target:getHealthPercentage()
-    return self:hasTarget() and (self:getHealth() / self:getMaxHealth()) or nil
-end
-
---[[
-Gets the maximum health of the specified unit.
-
-In the World of Warcraft API, the UnitHealthMax function is used to
-retrieve the maximum health of a specified unit. When you call
-UnitHealthMax('target'), it returns the maximum amount of health points
-that the targeted unit can have at full health. This function is commonly
-used by addon developers and players to track and display health-related
-information, such as health bars and percentages.
-]]
-function Target:getMaxHealth()
-    return self:hasTarget() and UnitHealthMax('target') or nil
-end
-
---[[
-Gets the target name.
-]]
-function Target:getName()
-    return UnitName('target')
-end
-
---[[
-Determines whether the player has a target or not.
-]]
-function Target:hasTarget()
-    return nil ~= self:getName()
-end
-
---[[
-Determines whether the target is alive.
-]]
-function Target:isAlive()
-    if self:hasTarget() then
-        return not self:isDead()
+    --[[
+    Target constructor.
+    ]]
+    function Target.__construct()
+        return setmetatable({}, Target)
     end
-    
-    return nil
-end
 
---[[
-Determines whether the target is dead.
-]]
-function Target:isDead()
-    return self:hasTarget() and UnitIsDeadOrGhost('target') or nil
-end
+    --[[
+    Gets the target GUID.
+    ]]
+    function Target:getGuid()
+        return UnitGUID('target')
+    end
 
---[[
-Determines whether the target is taggable or not.
+    --[[
+    Gets the target health.
 
-In Classic World of Warcraft, a taggable enemy is an enemy is an enemy that
-can grant experience, reputation, honor, loot, etc. Of course, that would
-depend on the enemy level, faction, etc. But this method checks if another
-player hasn't tagged the enemy before the current player.
+    In the World of Warcraft API, the UnitHealth('target') function behaves
+    differently for NPCs and other players. For NPCs, it returns the absolute
+    value of their health, whereas for players, it returns a value between
+    0 and 100 representing the percentage of their current health compared
+    to their total health.
+    ]]
+    function Target:getHealth()
+        return self:hasTarget() and UnitHealth('target') or nil
+    end
 
-As an example, if the player targets an enemy with a gray health bar, it
-means it's not taggable, then this method will return false.
-]]
-function Target:isTaggable()
-    if not self:hasTarget() then
+    --[[
+    Gets the target health in percentage.
+
+    This method returns a value between 0 and 1, representing the target's
+    health percentage.
+    ]]
+    function Target:getHealthPercentage()
+        return self:hasTarget() and (self:getHealth() / self:getMaxHealth()) or nil
+    end
+
+    --[[
+    Gets the maximum health of the specified unit.
+
+    In the World of Warcraft API, the UnitHealthMax function is used to
+    retrieve the maximum health of a specified unit. When you call
+    UnitHealthMax('target'), it returns the maximum amount of health points
+    that the targeted unit can have at full health. This function is commonly
+    used by addon developers and players to track and display health-related
+    information, such as health bars and percentages.
+    ]]
+    function Target:getMaxHealth()
+        return self:hasTarget() and UnitHealthMax('target') or nil
+    end
+
+    --[[
+    Gets the target name.
+    ]]
+    function Target:getName()
+        return UnitName('target')
+    end
+
+    --[[
+    Target marks in World of Warcraft are numbers from 0 to 8.
+
+    This method works as a helper to get the target mark index based on its
+    name or index. The name is a string, and the index is a number and for
+    more reference, see the MARKER_* constants in this class.
+    ]]
+    function Target:getTargetMarkIndex(targetNameOrIndex)
+        if (type(targetNameOrIndex) == 'number') then
+            return (targetNameOrIndex >= 0 and targetNameOrIndex <= 8) and targetNameOrIndex or nil
+        end
+
+        return self.__.arr:get(self.markers, targetNameOrIndex)
+    end
+
+    --[[
+    Determines whether the player has a target or not.
+    ]]
+    function Target:hasTarget()
+        return nil ~= self:getName()
+    end
+
+    --[[
+    Determines whether the target is alive.
+    ]]
+    function Target:isAlive()
+        if self:hasTarget() then
+            return not self:isDead()
+        end
+        
         return nil
     end
 
-    return not self:isNotTaggable()
-end
+    --[[
+    Determines whether the target is dead.
+    ]]
+    function Target:isDead()
+        return self:hasTarget() and UnitIsDeadOrGhost('target') or nil
+    end
 
---[[
-Determines whether the target is already tagged by other player.
+    --[[
+    Determines whether the target is taggable or not.
 
-Read Target::isTaggable() method's documentation for more information.
-]]
-function Target:isNotTaggable()
-    return UnitIsTapDenied('target')
-end
+    In Classic World of Warcraft, a taggable enemy is an enemy is an enemy that
+    can grant experience, reputation, honor, loot, etc. Of course, that would
+    depend on the enemy level, faction, etc. But this method checks if another
+    player hasn't tagged the enemy before the current player.
 
---[[
-Adds or removes a marker on the target based on a target icon index:
+    As an example, if the player targets an enemy with a gray health bar, it
+    means it's not taggable, then this method will return false.
+    ]]
+    function Target:isTaggable()
+        if not self:hasTarget() then
+            return nil
+        end
 
-0 - Removes any icons from the target
-1 = Yellow 4-point Star
-2 = Orange Circle
-3 = Purple Diamond
-4 = Green Triangle
-5 = White Crescent Moon
-6 = Blue Square
-7 = Red "X" Cross
-8 = White Skull
+        return not self:isNotTaggable()
+    end
 
-@see https://wowwiki-archive.fandom.com/wiki/API_SetRaidTarget
-]]
-function Target:mark(iconIndex)
-    SetRaidTarget('target', iconIndex)
-end
+    --[[
+    Determines whether the target is already tagged by other player.
+
+    Read Target::isTaggable() method's documentation for more information.
+    ]]
+    function Target:isNotTaggable()
+        return UnitIsTapDenied('target')
+    end
+
+    --[[
+    Adds or removes a marker on the target based on a target icon index:
+
+    0 - Removes any icons from the target
+    1 = Yellow 4-point Star
+    2 = Orange Circle
+    3 = Purple Diamond
+    4 = Green Triangle
+    5 = White Crescent Moon
+    6 = Blue Square
+    7 = Red "X" Cross
+    8 = White Skull
+
+    @see https://wowwiki-archive.fandom.com/wiki/API_SetRaidTarget
+
+    It's also possible to use the MARKER_* constants from this class.
+    ]]
+    function Target:mark(iconIndex)
+        markIndex = self:getTargetMarkIndex(iconIndex)
+
+        if nil ~= markIndex then SetRaidTarget('target', markIndex) end
+    end
+-- end of Target
 
 -- sets the unique library target instance
 self.target = Target.__construct()
-function self:getTarget() return self.target end

--- a/src/Models/Macro.lua
+++ b/src/Models/Macro.lua
@@ -1,6 +1,7 @@
 local Macro = {}
 Macro.__index = Macro
-self.classes['Macro'] = Macro
+Macro.__ = self
+self:addClass('Macro', Macro)
 
 --[[
 Macro constructor.
@@ -63,7 +64,7 @@ be separated by a line break.
 @return self
 ]]
 function Macro:setBody(value)
-    self.body = Arr:implode('\n', value)
+    self.body = __.arr:implode('\n', value)
     return self
 end
 

--- a/src/Models/Macro.lua
+++ b/src/Models/Macro.lua
@@ -64,7 +64,7 @@ be separated by a line break.
 @return self
 ]]
 function Macro:setBody(value)
-    self.body = __.arr:implode('\n', value)
+    self.body = self.__.arr:implode('\n', value)
     return self
 end
 

--- a/src/Models/Macro.lua
+++ b/src/Models/Macro.lua
@@ -1,96 +1,100 @@
+--[[
+The macro class maps macro information and allow in game macro updates.
+]]
 local Macro = {}
-Macro.__index = Macro
-Macro.__ = self
-self:addClass('Macro', Macro)
+    Macro.__index = Macro
+    Macro.__ = self
+    self:addClass('Macro', Macro)
 
---[[
-Macro constructor.
+    --[[
+    Macro constructor.
 
-@tparam string name the macro's name
-]]
-function Macro.__construct(name)
-    local self = setmetatable({}, Macro)
+    @tparam string name the macro's name
+    ]]
+    function Macro.__construct(name)
+        local self = setmetatable({}, Macro)
 
-    self.name = name
+        self.name = name
 
-    -- defaults
-    self:setIcon("INV_Misc_QuestionMark")
+        -- defaults
+        self:setIcon("INV_Misc_QuestionMark")
 
-    return self
-end
-
---[[
-Determines whether this macro exists.
-
-@treturn boolean
-]]
-function Macro:exists()
-    return GetMacroIndexByName(self.name) > 0
-end
-
---[[
-Saves the macro, returning the macro id.
-
-If the macro, identified by its name, doesn't exist yet, it will be created.
-
-It's important to mention that this whole Macro class can have weird
-behavior if it tries to save() a macro with dupicated names. Make sure this
-method is called for unique names.
-
-Future implementations may fix this issue, but as long as it uses unique
-names, this model will work as expected.
-
-@treturn integer the macro id
-]]
-function Macro:save()
-    if self:exists() then
-        return EditMacro(self.name, self.name, self.icon, self.body)
+        return self
     end
 
-    return CreateMacro(self.name, self.icon, self.body)
-end
+    --[[
+    Determines whether this macro exists.
 
---[[
-Sets the macro body.
+    @treturn boolean
+    ]]
+    function Macro:exists()
+        return GetMacroIndexByName(self.name) > 0
+    end
 
-The macro's body is the code that will be executed when the macro's
-triggered.
+    --[[
+    Saves the macro, returning the macro id.
 
-If the value is an array, it's considered a multiline body, and lines will
-be separated by a line break.
+    If the macro, identified by its name, doesn't exist yet, it will be created.
 
-@tparam array<string>|string value the macro's body
+    It's important to mention that this whole Macro class can have weird
+    behavior if it tries to save() a macro with dupicated names. Make sure this
+    method is called for unique names.
 
-@return self
-]]
-function Macro:setBody(value)
-    self.body = self.__.arr:implode('\n', value)
-    return self
-end
+    Future implementations may fix this issue, but as long as it uses unique
+    names, this model will work as expected.
 
---[[
-Sets the macro icon.
+    @treturn integer the macro id
+    ]]
+    function Macro:save()
+        if self:exists() then
+            return EditMacro(self.name, self.name, self.icon, self.body)
+        end
 
-@tparam integer|string value the macro's icon texture id
+        return CreateMacro(self.name, self.icon, self.body)
+    end
 
-@return self
-]]
-function Macro:setIcon(value)
-    self.icon = value
-    return self
-end
+    --[[
+    Sets the macro body.
 
---[[
-Sets the macro name.
+    The macro's body is the code that will be executed when the macro's
+    triggered.
 
-This is the macro's identifier, which means the one World of Warcraft API
-will use when accessing the game's macro.
+    If the value is an array, it's considered a multiline body, and lines will
+    be separated by a line break.
 
-@tparam string value the macro's name
+    @tparam array<string>|string value the macro's body
 
-@return self
-]]
-function Macro:setName(value)
-    self.name = value
-    return self
-end
+    @return self
+    ]]
+    function Macro:setBody(value)
+        self.body = self.__.arr:implode('\n', value)
+        return self
+    end
+
+    --[[
+    Sets the macro icon.
+
+    @tparam integer|string value the macro's icon texture id
+
+    @return self
+    ]]
+    function Macro:setIcon(value)
+        self.icon = value
+        return self
+    end
+
+    --[[
+    Sets the macro name.
+
+    This is the macro's identifier, which means the one World of Warcraft API
+    will use when accessing the game's macro.
+
+    @tparam string value the macro's name
+
+    @return self
+    ]]
+    function Macro:setName(value)
+        self.name = value
+        return self
+    end
+-- end of Macro

--- a/src/Support/Arr.lua
+++ b/src/Support/Arr.lua
@@ -2,188 +2,189 @@
 The Arr support class contains helper functions to manipulate arrays.
 ]]
 local Arr = {}
-Arr.__index = Arr
-Arr.__ = self
+    Arr.__index = Arr
+    Arr.__ = self
 
---[[
-Gets a value in an array using the dot notation.
+    --[[
+    Gets a value in an array using the dot notation.
 
-With the dot notation search, it's possible to query a value in a multidimensional array
-by passing a single string containing keys separated by dot.
-]]
-function Arr:get(list, key, default)
-    local keys = self.__.str:split(key, '.')
-    local current = list[keys[1]]
+    With the dot notation search, it's possible to query a value in a multidimensional array
+    by passing a single string containing keys separated by dot.
+    ]]
+    function Arr:get(list, key, default)
+        local keys = self.__.str:split(key, '.')
+        local current = list[keys[1]]
 
-    for i = 2, #keys do current = current and current[keys[i]] or nil end
+        for i = 2, #keys do current = current and current[keys[i]] or nil end
 
-    return current or default
-end
-
---[[
-Combines the elements of a table into a single string, separated by a
-specified delimiter.
-
-@tparam string the delimiter used to separate the elements in the resulting string
-@tparam array the table containing elements to be combined into a string
-
-@treturn string
-]]
-function Arr:implode(delimiter, list)
-    if not (self:isArray(list)) then
-        return list
+        return current or default
     end
 
-    local result = ""
-    local length = #list
-    for i, v in ipairs(list) do
-        result = result .. v
-        if i < length then
-            result = result .. delimiter
+    --[[
+    Combines the elements of a table into a single string, separated by a
+    specified delimiter.
+
+    @tparam string the delimiter used to separate the elements in the resulting string
+    @tparam array the table containing elements to be combined into a string
+
+    @treturn string
+    ]]
+    function Arr:implode(delimiter, list)
+        if not (self:isArray(list)) then
+            return list
         end
-    end
-    return result
-end
 
---[[
-Determines whether a value is in an array.
-
-If so, returns true and the index, false and 0 otherwise.
-
-Class instances can also be checked in this method, not only primitive
-types, as long as they implement the __eq method.
-
-@treturn boolean, int
-]]
-function Arr:inArray(list, value)
-    local results = {}
-
-    for i, val in pairs(list) do
-        if val == value then
-            return true, i
+        local result = ""
+        local length = #list
+        for i, v in ipairs(list) do
+            result = result .. v
+            if i < length then
+                result = result .. delimiter
+            end
         end
+        return result
     end
 
-    return false, 0
-end
+    --[[
+    Determines whether a value is in an array.
 
---[[
-Inserts a value in an array if it's not in the array yet.
+    If so, returns true and the index, false and 0 otherwise.
 
-It's important to mention that this method only works for arrays with
-numeric indexes. After all, if using string keys, there's no need to check,
-but only setting and replacing the value.
+    Class instances can also be checked in this method, not only primitive
+    types, as long as they implement the __eq method.
 
-Class instances can also be passed as the value, not only primitive types,
-as long as they implement the __eq method.
-]]
-function Arr:insertNotInArray(list, value)
-    if not self:isArray(list) or self:inArray(list, value) then
+    @treturn boolean, int
+    ]]
+    function Arr:inArray(list, value)
+        local results = {}
+
+        for i, val in pairs(list) do
+            if val == value then
+                return true, i
+            end
+        end
+
+        return false, 0
+    end
+
+    --[[
+    Inserts a value in an array if it's not in the array yet.
+
+    It's important to mention that this method only works for arrays with
+    numeric indexes. After all, if using string keys, there's no need to check,
+    but only setting and replacing the value.
+
+    Class instances can also be passed as the value, not only primitive types,
+    as long as they implement the __eq method.
+    ]]
+    function Arr:insertNotInArray(list, value)
+        if not self:isArray(list) or self:inArray(list, value) then
+            return false
+        end
+
+        table.insert(list, value)
+        return true
+    end
+
+    --[[
+    Determines whether the value is an array or not.
+
+    The function checks whether the parameter passed is a table in Lua.
+    If it is, it iterates over the table's key-value pairs, examining each key
+    to determine if it is numeric. If all keys are numeric, indicating an
+    array-like structure, the function returns true; otherwise, it returns
+    false.
+
+    This strategy leverages Lua's type checking and table iteration
+    capabilities to ascertain whether the input value qualifies as an array.
+
+    @return boolean
+    ]]
+    function Arr:isArray(value)
+        if type(value) == "table" then
+            local isArray = true
+            for k, v in pairs(value) do
+                if type(k) ~= "number" then
+                    isArray = false
+                    break
+                end
+            end
+            return isArray
+        end
         return false
     end
 
-    table.insert(list, value)
-    return true
-end
+    --[[
+    Iterates over the list values and calls the callback function in the second
+    argument for each of them.
 
---[[
-Determines whether the value is an array or not.
+    The callback function must be a function that accepts (val) or (val, i)
+    where val is the object in the interaction and i it's index.
 
-The function checks whether the parameter passed is a table in Lua.
-If it is, it iterates over the table's key-value pairs, examining each key
-to determine if it is numeric. If all keys are numeric, indicating an
-array-like structure, the function returns true; otherwise, it returns
-false.
+    This method accepts arrays and tables.
+    ]]
+    function Arr:map(list, callback)
+        local results = {}
 
-This strategy leverages Lua's type checking and table iteration
-capabilities to ascertain whether the input value qualifies as an array.
+        for i, val in pairs(list) do results[i] = callback(val, i) end
 
-@return boolean
-]]
-function Arr:isArray(value)
-    if type(value) == "table" then
-        local isArray = true
-        for k, v in pairs(value) do
-            if type(k) ~= "number" then
-                isArray = false
-                break
+        return results
+    end
+
+    --[[
+    Initializes a value in a table if it's not initialized yet.
+
+    The key accepts a dot notation key just like get() and set().
+    ]]
+    function Arr:maybeInitialize(list, key, initialValue)
+        if self:get(list, key) == nil then self:set(list, key, initialValue) end
+    end
+
+    --[[
+    Extracts a list of values from a list of objects based on a given key.
+
+    It's important to mention that nil values won't be returned in the
+    resulted list. Which means: objects that have no property or when their
+    properties are nil, the values won't be returned. That said, a list with n
+    items can return a smaller list.
+
+    The key accepts a dot notation key just like get() and set().
+    ]]
+    function Arr:pluck(list, key)
+        local results = {}
+        for _, item in ipairs(list) do
+            table.insert(results, self:get(item, key))
+        end
+        return results
+    end
+
+    --[[
+    Sets a value using arrays dot notation.
+
+    It will basically iterate over the keys separated by "." and create
+    the missing indexes, finally setting the last key with the value in
+    the args list.
+    ]]
+    function Arr:set(list, key, value)
+        local keys = self.__.str:split(key, '.')
+        local current = list
+
+        for i = 1, #keys do
+            local key = keys[i]
+
+            if i == #keys then
+                -- this is the last key, so just the value and return
+                current[key] = value
+                return
             end
+
+            -- creates an empty table
+            if current[key] == nil then current[key] = {} end
+            
+            -- sets the "pointer" for the next iteration
+            current = current[key]
         end
-        return isArray
     end
-    return false
-end
-
---[[
-Iterates over the list values and calls the callback function in the second
-argument for each of them.
-
-The callback function must be a function that accepts (val) or (val, i)
-where val is the object in the interaction and i it's index.
-
-This method accepts arrays and tables.
-]]
-function Arr:map(list, callback)
-    local results = {}
-
-    for i, val in pairs(list) do results[i] = callback(val, i) end
-
-    return results
-end
-
---[[
-Initializes a value in a table if it's not initialized yet.
-
-The key accepts a dot notation key just like get() and set().
-]]
-function Arr:maybeInitialize(list, key, initialValue)
-    if self:get(list, key) == nil then self:set(list, key, initialValue) end
-end
-
---[[
-Extracts a list of values from a list of objects based on a given key.
-
-It's important to mention that nil values won't be returned in the
-resulted list. Which means: objects that have no property or when their
-properties are nil, the values won't be returned. That said, a list with n
-items can return a smaller list.
-
-The key accepts a dot notation key just like get() and set().
-]]
-function Arr:pluck(list, key)
-    local results = {}
-    for _, item in ipairs(list) do
-        table.insert(results, self:get(item, key))
-    end
-    return results
-end
-
---[[
-Sets a value using arrays dot notation.
-
-It will basically iterate over the keys separated by "." and create
-the missing indexes, finally setting the last key with the value in
-the args list.
-]]
-function Arr:set(list, key, value)
-    local keys = self.__.str:split(key, '.')
-    local current = list
-
-    for i = 1, #keys do
-        local key = keys[i]
-
-        if i == #keys then
-            -- this is the last key, so just the value and return
-            current[key] = value
-            return
-        end
-
-        -- creates an empty table
-        if current[key] == nil then current[key] = {} end
-        
-        -- sets the "pointer" for the next iteration
-        current = current[key]
-    end
-end
+-- end of Arr
 
 self.arr = Arr

--- a/src/Support/Arr.lua
+++ b/src/Support/Arr.lua
@@ -46,6 +46,25 @@ function Arr:implode(delimiter, list)
 end
 
 --[[
+Determines whether a value is in an array.
+
+If so, returns true and the index, false and 0 otherwise.
+
+@treturn boolean, int
+]]
+function Arr:inArray(list, value)
+    local results = {}
+
+    for i, val in pairs(list) do
+        if val == value then
+            return true, i
+        end
+    end
+
+    return false, 0
+end
+
+--[[
 Determines whether the value is an array or not.
 
 The function checks whether the parameter passed is a table in Lua.

--- a/src/Support/Arr.lua
+++ b/src/Support/Arr.lua
@@ -50,6 +50,9 @@ Determines whether a value is in an array.
 
 If so, returns true and the index, false and 0 otherwise.
 
+Class instances can also be checked in this method, not only primitive
+types, as long as they implement the __eq method.
+
 @treturn boolean, int
 ]]
 function Arr:inArray(list, value)
@@ -62,6 +65,25 @@ function Arr:inArray(list, value)
     end
 
     return false, 0
+end
+
+--[[
+Inserts a value in an array if it it's not in the array yet.
+
+It's important to mention that this method only works for arrays with
+numeric indexes. After all, if using string keys, there's no need to check,
+but only setting and replacing the value.
+
+Class instances can also be passed as the value, not only primitive types,
+as long as they implement the __eq method.
+]]
+function Arr:insertNotInArray(list, value)
+    if not self:isArray(list) or self:inArray(list, value) then
+        return false
+    end
+
+    table.insert(list, value)
+    return true
 end
 
 --[[

--- a/src/Support/Arr.lua
+++ b/src/Support/Arr.lua
@@ -6,7 +6,10 @@ Arr.__index = Arr
 Arr.__ = self
 
 --[[
-    @TODO: Keep working here
+Gets a value in an array using the dot notation.
+
+With the dot notation search, it's possible to query a value in a multidimensional array
+by passing a single string containing keys separated by dot.
 ]]
 function Arr:get(list, key, default)
     local keys = __.str:split(key, '.')
@@ -68,6 +71,33 @@ function Arr:isArray(value)
         return isArray
     end
     return false
+end
+
+--[[
+Sets a value using arrays dot notation.
+
+It will basically iterate over the keys separated by "." and create
+the missing indexes, finally setting the last key with the value in
+the args list.
+]]
+function Arr:set(list, key, value)
+    local keys = __.str:split(key, '.')
+    local current = list
+
+    for i = 1, #keys do
+        local key = keys[i]
+
+        if i == #keys then
+            -- this is the last key, so just the value and return
+            current[key] = value
+            return
+        end
+
+        -- sets the "pointer" for the next iteration
+        if current[key] == nil then current[key] = {} end
+        
+        current = current[key]
+    end
 end
 
 self.arr = Arr

--- a/src/Support/Arr.lua
+++ b/src/Support/Arr.lua
@@ -68,7 +68,7 @@ function Arr:inArray(list, value)
 end
 
 --[[
-Inserts a value in an array if it it's not in the array yet.
+Inserts a value in an array if it's not in the array yet.
 
 It's important to mention that this method only works for arrays with
 numeric indexes. After all, if using string keys, there's no need to check,
@@ -138,6 +138,24 @@ The key accepts a dot notation key just like get() and set().
 ]]
 function Arr:maybeInitialize(list, key, initialValue)
     if self:get(list, key) == nil then self:set(list, key, initialValue) end
+end
+
+--[[
+Extracts a list of values from a list of objects based on a given key.
+
+It's important to mention that nil values won't be returned in the
+resulted list. Which means: objects that have no property or when their
+properties are nil, the values won't be returned. That said, a list with n
+items can return a smaller list.
+
+The key accepts a dot notation key just like get() and set().
+]]
+function Arr:pluck(list, key)
+    local results = {}
+    for _, item in ipairs(list) do
+        table.insert(results, self:get(item, key))
+    end
+    return results
 end
 
 --[[

--- a/src/Support/Arr.lua
+++ b/src/Support/Arr.lua
@@ -12,7 +12,7 @@ With the dot notation search, it's possible to query a value in a multidimension
 by passing a single string containing keys separated by dot.
 ]]
 function Arr:get(list, key, default)
-    local keys = __.str:split(key, '.')
+    local keys = self.__.str:split(key, '.')
     local current = list[keys[1]]
 
     for i = 2, #keys do current = current and current[keys[i]] or nil end
@@ -90,7 +90,7 @@ the missing indexes, finally setting the last key with the value in
 the args list.
 ]]
 function Arr:set(list, key, value)
-    local keys = __.str:split(key, '.')
+    local keys = self.__.str:split(key, '.')
     local current = list
 
     for i = 1, #keys do

--- a/src/Support/Arr.lua
+++ b/src/Support/Arr.lua
@@ -3,6 +3,19 @@ The Arr support class contains helper functions to manipulate arrays.
 ]]
 local Arr = {}
 Arr.__index = Arr
+Arr.__ = self
+
+--[[
+    @TODO: Keep working here
+]]
+function Arr:get(list, key, default)
+    local keys = __.str:split(key, '.')
+    local current = list[keys[1]]
+
+    for i = 2, #keys do current = current and current[keys[i]] or nil end
+
+    return current or default
+end
 
 --[[
 Combines the elements of a table into a single string, separated by a

--- a/src/Support/Arr.lua
+++ b/src/Support/Arr.lua
@@ -74,6 +74,15 @@ function Arr:isArray(value)
 end
 
 --[[
+Initializes a value in a table if it's not initialized yet.
+
+The key accepts a dot notation key just like get() and set().
+]]
+function Arr:maybeInitialize(list, key, initialValue)
+    if self:get(list, key) == nil then self:set(list, key, initialValue) end
+end
+
+--[[
 Sets a value using arrays dot notation.
 
 It will basically iterate over the keys separated by "." and create
@@ -93,9 +102,10 @@ function Arr:set(list, key, value)
             return
         end
 
-        -- sets the "pointer" for the next iteration
+        -- creates an empty table
         if current[key] == nil then current[key] = {} end
         
+        -- sets the "pointer" for the next iteration
         current = current[key]
     end
 end

--- a/src/Support/Arr.lua
+++ b/src/Support/Arr.lua
@@ -74,6 +74,23 @@ function Arr:isArray(value)
 end
 
 --[[
+Iterates over the list values and calls the callback function in the second
+argument for each of them.
+
+The callback function must be a function that accepts (val) or (val, i)
+where val is the object in the interaction and i it's index.
+
+This method accepts arrays and tables.
+]]
+function Arr:map(list, callback)
+    local results = {}
+
+    for i, val in pairs(list) do results[i] = callback(val, i) end
+
+    return results
+end
+
+--[[
 Initializes a value in a table if it's not initialized yet.
 
 The key accepts a dot notation key just like get() and set().

--- a/src/Support/Arr.lua
+++ b/src/Support/Arr.lua
@@ -159,6 +159,24 @@ local Arr = {}
     end
 
     --[[
+    Removes a value from an indexed array.
+
+    Tables with non numeric keys won't be affected by this method.
+
+    The value must be the value to be removed and not the index.
+    ]]
+    function Arr:remove(list, value)
+        if not self:isArray(list) then return false end
+
+        local found, index = self:inArray(list, value)
+
+        if not found then return false end
+
+        table.remove(list, index)
+        return true
+    end
+
+    --[[
     Sets a value using arrays dot notation.
 
     It will basically iterate over the keys separated by "." and create

--- a/src/Support/Str.lua
+++ b/src/Support/Str.lua
@@ -1,0 +1,23 @@
+--[[
+The Str support class contains helper functions to manipulate strings.
+]]
+local Str = {}
+Str.__index = Str
+
+--[[
+Splits a string in a table by breaking it where the separator is found.
+
+@tparam string value
+@tparam string separator
+
+@treturn table
+]]
+function Str:split(value, separator)
+    local values = {}
+    for str in string.gmatch(value, "([^"..separator.."]+)") do
+        table.insert(values, str)
+    end
+    return values
+end
+
+self.str = Str

--- a/src/Support/Str.lua
+++ b/src/Support/Str.lua
@@ -2,22 +2,23 @@
 The Str support class contains helper functions to manipulate strings.
 ]]
 local Str = {}
-Str.__index = Str
+    Str.__index = Str
 
---[[
-Splits a string in a table by breaking it where the separator is found.
+    --[[
+    Splits a string in a table by breaking it where the separator is found.
 
-@tparam string value
-@tparam string separator
+    @tparam string value
+    @tparam string separator
 
-@treturn table
-]]
-function Str:split(value, separator)
-    local values = {}
-    for str in string.gmatch(value, "([^"..separator.."]+)") do
-        table.insert(values, str)
+    @treturn table
+    ]]
+    function Str:split(value, separator)
+        local values = {}
+        for str in string.gmatch(value, "([^"..separator.."]+)") do
+            table.insert(values, str)
+        end
+        return values
     end
-    return values
-end
+-- end of Str
 
 self.str = Str

--- a/src/stormwind-library.lua
+++ b/src/stormwind-library.lua
@@ -1,4 +1,4 @@
--- Library version = '0.0.5'
+-- Library version = '0.0.6'
 
 -- import src/Core/Factory.lua
 

--- a/src/stormwind-library.lua
+++ b/src/stormwind-library.lua
@@ -7,3 +7,4 @@
 -- import src/Models/Macro.lua
 
 -- import src/Support/Arr.lua
+-- import src/Support/Str.lua

--- a/tests/Core/FactoryTest.lua
+++ b/tests/Core/FactoryTest.lua
@@ -1,0 +1,25 @@
+--[[
+@covers Factory.classes
+@covers Factory:addClass()
+@covers Factory:new()
+]]
+function testFactoryCanInstantiateClasses()
+    local MockClass = {}
+    MockClass.__index = MockClass
+
+    function MockClass.__construct(name)
+        local self = setmetatable({}, MockClass)
+        self.name = name
+        return self
+    end
+
+    local library = newLibrary()
+    library:addClass('MockClass', MockClass)
+
+    lu.assertNotIsNil(library.classes)
+
+    local mockClassInstance = library:new('MockClass', 'test-name')
+
+    lu.assertNotIsNil(mockClassInstance)
+    lu.assertEquals(mockClassInstance.name, 'test-name')
+end

--- a/tests/Core/FactoryTest.lua
+++ b/tests/Core/FactoryTest.lua
@@ -22,6 +22,6 @@ TestFactory = {}
         local mockClassInstance = library:new('MockClass', 'test-name')
 
         lu.assertNotIsNil(mockClassInstance)
-        lu.assertEquals(mockClassInstance.name, 'test-name')
+        lu.assertEquals('test-name', mockClassInstance.name)
     end
 -- end of TestFactory

--- a/tests/Core/FactoryTest.lua
+++ b/tests/Core/FactoryTest.lua
@@ -1,25 +1,27 @@
---[[
-@covers Factory.classes
-@covers Factory:addClass()
-@covers Factory:new()
-]]
-function testFactoryCanInstantiateClasses()
-    local MockClass = {}
-    MockClass.__index = MockClass
+TestFactory = {}
+    --[[
+    @covers Factory.classes
+    @covers Factory:addClass()
+    @covers Factory:new()
+    ]]
+    function TestFactory:testCanInstantiateClasses()
+        local MockClass = {}
+        MockClass.__index = MockClass
 
-    function MockClass.__construct(name)
-        local self = setmetatable({}, MockClass)
-        self.name = name
-        return self
+        function MockClass.__construct(name)
+            local self = setmetatable({}, MockClass)
+            self.name = name
+            return self
+        end
+
+        local library = newLibrary()
+        library:addClass('MockClass', MockClass)
+
+        lu.assertNotIsNil(library.classes)
+
+        local mockClassInstance = library:new('MockClass', 'test-name')
+
+        lu.assertNotIsNil(mockClassInstance)
+        lu.assertEquals(mockClassInstance.name, 'test-name')
     end
-
-    local library = newLibrary()
-    library:addClass('MockClass', MockClass)
-
-    lu.assertNotIsNil(library.classes)
-
-    local mockClassInstance = library:new('MockClass', 'test-name')
-
-    lu.assertNotIsNil(mockClassInstance)
-    lu.assertEquals(mockClassInstance.name, 'test-name')
-end
+-- end of TestFactory

--- a/tests/Facades/TargetTest.lua
+++ b/tests/Facades/TargetTest.lua
@@ -1,8 +1,8 @@
---[[
-@covers StormwindLibrary:getTarget()
-]]
-function testTargetCanGetTargetFacade()
-    local target = __:getTarget()
+TestTarget = {}
+    -- @covers StormwindLibrary:getTarget()
+    function TestTarget:testCanGetTargetFacade()
+        local target = __:getTarget()
 
-    lu.assertNotIsNil(target)
-end
+        lu.assertNotIsNil(target)
+    end
+-- end of TestTarget

--- a/tests/Facades/TargetTest.lua
+++ b/tests/Facades/TargetTest.lua
@@ -23,7 +23,7 @@ TestTarget = {}
         local target = __.target
 
         local function execution(targetNameOrIndex, expectedIndex)
-            lu.assertEquals(target:getTargetMarkIndex(targetNameOrIndex), expectedIndex)
+            lu.assertEquals(expectedIndex, target:getTargetMarkIndex(targetNameOrIndex))
         end
 
         execution(-1, nil)
@@ -66,7 +66,7 @@ TestTarget = {}
             local target = __.target
             target:mark(markNameOrIndex)
 
-            lu.assertEquals(setRaidTargetInvoked, shouldMark)
+            lu.assertEquals(shouldMark, setRaidTargetInvoked)
         end
 
         execution(-1, false)

--- a/tests/Facades/TargetTest.lua
+++ b/tests/Facades/TargetTest.lua
@@ -1,8 +1,80 @@
 TestTarget = {}
     -- @covers StormwindLibrary:getTarget()
-    function TestTarget:testCanGetTargetFacade()
-        local target = __:getTarget()
+    function TestTarget:testGetTargetFacade()
+        local target = __.target
 
         lu.assertNotIsNil(target)
+
+        lu.assertNotIsNil(target.MARKER_CIRCLE)
+        lu.assertNotIsNil(target.MARKER_DIAMOND)
+        lu.assertNotIsNil(target.MARKER_MOON)
+        lu.assertNotIsNil(target.MARKER_REMOVE)
+        lu.assertNotIsNil(target.MARKER_SKULL)
+        lu.assertNotIsNil(target.MARKER_SQUARE)
+        lu.assertNotIsNil(target.MARKER_STAR)
+        lu.assertNotIsNil(target.MARKER_TRIANGLE)
+        lu.assertNotIsNil(target.MARKER_X)
+
+        lu.assertIsTable(target.markers)
+    end
+
+    -- @covers StormwindLibrary:getTargetMarkIndex()
+    function TestTarget:testGetTargetMarkIndex()
+        local target = __.target
+
+        local function execution(targetNameOrIndex, expectedIndex)
+            lu.assertEquals(target:getTargetMarkIndex(targetNameOrIndex), expectedIndex)
+        end
+
+        execution(-1, nil)
+        for i = 0, 8 do execution(i, i) end
+        execution(9, nil)
+
+        execution('remove', 0)
+        execution('star', 1)
+        execution('circle', 2)
+        execution('diamond', 3)
+        execution('triangle', 4)
+        execution('moon', 5)
+        execution('square', 6)
+        execution('x', 7)
+        execution('skull', 8)
+        execution('invalid', nil)
+
+        execution(target.MARKER_REMOVE, 0)
+        execution(target.MARKER_STAR, 1)
+        execution(target.MARKER_CIRCLE, 2)
+        execution(target.MARKER_DIAMOND, 3)
+        execution(target.MARKER_TRIANGLE, 4)
+        execution(target.MARKER_MOON, 5)
+        execution(target.MARKER_SQUARE, 6)
+        execution(target.MARKER_X, 7)
+        execution(target.MARKER_SKULL, 8)
+    end
+    
+    -- @covers Target:mark()
+    function TestTarget:testMark()
+        -- allows restoring the original SetRaidTarget function if needed
+        local originalSetRaidTarget = SetRaidTarget
+
+        local setRaidTargetInvoked = false
+        SetRaidTarget = function() setRaidTargetInvoked = true end
+
+        local function execution(markNameOrIndex, shouldMark)
+            setRaidTargetInvoked = false
+
+            local target = __.target
+            target:mark(markNameOrIndex)
+
+            lu.assertEquals(setRaidTargetInvoked, shouldMark)
+        end
+
+        execution(-1, false)
+        execution(0, true)
+        for i = 0, 8 do execution(i, true) end
+        execution(9, false)
+
+        -- restores the original SetRaidTarget function
+        SetRaidTarget = originalSetRaidTarget
     end
 -- end of TestTarget

--- a/tests/Models/MacroTest.lua
+++ b/tests/Models/MacroTest.lua
@@ -4,7 +4,7 @@ TestMacro = {}
         local macro = __:new('Macro', 'test-macro')
 
         lu.assertNotIsNil(macro)
-        lu.assertEquals(macro.name, 'test-macro')
+        lu.assertEquals('test-macro', macro.name)
     end
 
     -- @covers Macro:setBody()
@@ -13,6 +13,6 @@ TestMacro = {}
 
         macro:setBody('test-body')
 
-        lu.assertEquals(macro.body, 'test-body')
+        lu.assertEquals('test-body', macro.body)
     end
 -- end of TestMacro

--- a/tests/Models/MacroTest.lua
+++ b/tests/Models/MacroTest.lua
@@ -1,0 +1,20 @@
+--[[
+@covers Macro:__construct()
+]]
+function testMacroCanInstantiate()
+    local macro = __:new('Macro', 'test-macro')
+
+    lu.assertNotIsNil(macro)
+    lu.assertEquals(macro.name, 'test-macro')
+end
+
+--[[
+@covers Macro:setBody()
+]]
+function testMacroCanSetBody()
+    local macro = __:new('Macro', 'test-macro')
+
+    macro:setBody('test-body')
+
+    lu.assertEquals(macro.body, 'test-body')
+end

--- a/tests/Models/MacroTest.lua
+++ b/tests/Models/MacroTest.lua
@@ -1,20 +1,18 @@
---[[
-@covers Macro:__construct()
-]]
-function testMacroCanInstantiate()
-    local macro = __:new('Macro', 'test-macro')
+TestMacro = {}
+    -- @covers Macro:__construct()
+    function TestMacro:testCanInstantiate()
+        local macro = __:new('Macro', 'test-macro')
 
-    lu.assertNotIsNil(macro)
-    lu.assertEquals(macro.name, 'test-macro')
-end
+        lu.assertNotIsNil(macro)
+        lu.assertEquals(macro.name, 'test-macro')
+    end
 
---[[
-@covers Macro:setBody()
-]]
-function testMacroCanSetBody()
-    local macro = __:new('Macro', 'test-macro')
+    -- @covers Macro:setBody()
+    function TestMacro:testCanSetBody()
+        local macro = __:new('Macro', 'test-macro')
 
-    macro:setBody('test-body')
+        macro:setBody('test-body')
 
-    lu.assertEquals(macro.body, 'test-body')
-end
+        lu.assertEquals(macro.body, 'test-body')
+    end
+-- end of TestMacro

--- a/tests/Support/ArrTest.lua
+++ b/tests/Support/ArrTest.lua
@@ -101,6 +101,42 @@ function testArrCanSet()
     lu.assertEquals(arr:get(list, 'a.b'), 'test-initial')
 end
 
+-- @see testArrInArray
+local function testArrInArrayExecution(list, value, expectedResult, expectedIndex)
+    local result, index = __.arr:inArray(list, value)
+    
+    lu.assertEquals(result, expectedResult)
+    lu.assertEquals(index, expectedIndex)
+end
+
+--[[
+@covers Arr:inArray()
+]]
+function testArrInArray()
+    testArrInArrayExecution({}, nil, false, 0)
+    testArrInArrayExecution({'a', 'b', 'c'}, 'd', false, 0)
+    testArrInArrayExecution({'a', 'b', 'c'}, 'a', true, 1)
+    testArrInArrayExecution({'a', 'b', 'c'}, 'c', true, 3)
+    testArrInArrayExecution({a = 'a', b = 'b', c = 'c'}, 'c', true, 'c')
+
+    local ComparableObject = {}
+    ComparableObject.__index = ComparableObject
+    ComparableObject.__ = self
+    function ComparableObject:new(value)
+        local self = setmetatable({}, ComparableObject)
+        self.value = value
+        return self
+    end
+    function ComparableObject:__eq(object) return self.value == object.value end
+
+    local objectA = ComparableObject:new('test-object-a')
+    local objectB = ComparableObject:new('test-object-b')
+    local objectC = ComparableObject:new('test-object-c')
+
+    testArrInArrayExecution({objectA, objectB}, objectC, false, 0)
+    testArrInArrayExecution({objectA, objectB}, objectB, true, 2)
+end
+
 --[[
 @covers Arr:isArray()
 ]]

--- a/tests/Support/ArrTest.lua
+++ b/tests/Support/ArrTest.lua
@@ -56,6 +56,24 @@ function testArrCanImplodeWithNonList()
     lu.assertEquals(result, text)
 end
 
+-- @see testCanInsertNotInArray
+local function testCanInsertNotInArrayExecution(list, value, expectedBooleanResult, expectedListResult)
+    local booleanResult = __.arr:insertNotInArray(list, value)
+
+    lu.assertEquals(booleanResult, expectedBooleanResult)
+    lu.assertEquals(list, expectedListResult)
+end
+
+--[[
+@covers Arr:insertNotInArray()
+]]
+function testCanInsertNotInArray()
+    testCanInsertNotInArrayExecution('a', 'a', false, 'a')
+    testCanInsertNotInArrayExecution({}, 'a', true, {'a'})
+    testCanInsertNotInArrayExecution({'a'}, 'a', false, {'a'})
+    testCanInsertNotInArrayExecution({'a'}, 'b', true, {'a', 'b'})
+end
+
 -- @see testArrCanMap
 local function testArrCanMapExecution(list, expectedOutput)
     local arr = __.arr

--- a/tests/Support/ArrTest.lua
+++ b/tests/Support/ArrTest.lua
@@ -183,4 +183,18 @@ TestArr = {}
 
         execution({objectA, objectB, objectC}, 'test-key.test-nested-key', {'test-value'})
     end
+
+    -- @covers Arr:remove()
+    function TestArr:testRemove()
+        local execution = function(list, key, expectedOutput)
+            local arr = __.arr
+            arr:remove(list, key)
+            lu.assertEquals(list, expectedOutput)
+        end
+
+        execution({}, 'test', {})
+        execution({'a', 'b', 'c'}, 'a', {'b', 'c'})
+        execution({1, 2, 3}, 2, {1, 3})
+        execution({a = 'a', b = 'b', c = 'c'}, 'a', {a = 'a', b = 'b', c = 'c'})
+    end
 -- end of TestArr

--- a/tests/Support/ArrTest.lua
+++ b/tests/Support/ArrTest.lua
@@ -56,6 +56,26 @@ function testArrCanImplodeWithNonList()
     lu.assertEquals(result, text)
 end
 
+-- @see testArrCanMap
+local function testArrCanMapExecution(list, expectedOutput)
+    local arr = __.arr
+
+    local results = __.arr:map(list, function (val, i)
+        return val .. '-' .. i
+    end)
+
+    lu.assertEquals(results, expectedOutput)
+end
+
+--[[
+@covers Arr:map()
+]]
+function testArrCanMap()
+    testArrCanMapExecution({}, {})
+    testArrCanMapExecution({'test', 'test', 'test'}, {'test-1', 'test-2', 'test-3'})
+    testArrCanMapExecution({['a'] = 'a', ['b'] = 'b', ['c'] = 'c'}, {['a'] = 'a-a', ['b'] = 'b-b', ['c'] = 'c-c'})
+end
+
 --[[
 @covers Arr:set()
 ]]

--- a/tests/Support/ArrTest.lua
+++ b/tests/Support/ArrTest.lua
@@ -2,7 +2,7 @@ TestArr = {}
     -- @covers Arr:get()
     function TestArr:testCanGet()
         local function execution(list, key, default, expectedOutput)
-            lu.assertEquals(__.arr:get(list, key, default), expectedOutput)
+            lu.assertEquals(expectedOutput, __.arr:get(list, key, default))
         end
 
         execution({}, 'test', nil, nil)
@@ -35,7 +35,7 @@ TestArr = {}
 
         local result = arr:implode(delimiter, list)
 
-        lu.assertEquals(result, 'a,b,c')
+        lu.assertEquals('a,b,c', result)
     end
 
     -- @covers Arr:implode()
@@ -45,7 +45,7 @@ TestArr = {}
         local text = 'test'
         local result = arr:implode(',', text)
 
-        lu.assertEquals(result, text)
+        lu.assertEquals(text, result)
     end
 
     -- @covers Arr:insertNotInArray()
@@ -53,8 +53,8 @@ TestArr = {}
         local function execution(list, value, expectedBooleanResult, expectedListResult)
             local booleanResult = __.arr:insertNotInArray(list, value)
     
-            lu.assertEquals(booleanResult, expectedBooleanResult)
-            lu.assertEquals(list, expectedListResult)
+            lu.assertEquals(expectedBooleanResult, booleanResult)
+            lu.assertEquals(expectedListResult, list)
         end
 
         execution('a', 'a', false, 'a')
@@ -72,7 +72,7 @@ TestArr = {}
                 return val .. '-' .. i
             end)
     
-            lu.assertEquals(results, expectedOutput)
+            lu.assertEquals(expectedOutput, results)
         end
 
         execution({}, {})
@@ -89,7 +89,7 @@ TestArr = {}
         list['a']['b'] = 'test-initial'
 
         -- sanity checks to make sure the list is consistent
-        lu.assertEquals(arr:get(list, 'a.b'), 'test-initial')
+        lu.assertEquals('test-initial', arr:get(list, 'a.b'))
         lu.assertIsNil(arr:get(list, 'a.c'))
         lu.assertIsNil(arr:get(list, 'x.y.z'))
 
@@ -98,9 +98,9 @@ TestArr = {}
         arr:set(list, 'x.y.z', 'test-with-three-levels')
 
         -- checks if the property 
-        lu.assertEquals(arr:get(list, 'a.c'), 'test-with-set')
-        lu.assertEquals(arr:get(list, 'x.y.z'), 'test-with-three-levels')
-        lu.assertEquals(arr:get(list, 'a.b'), 'test-initial')
+        lu.assertEquals('test-with-set', arr:get(list, 'a.c'))
+        lu.assertEquals('test-with-three-levels', arr:get(list, 'x.y.z'))
+        lu.assertEquals('test-initial', arr:get(list, 'a.b'))
     end
 
     -- @covers Arr:inArray()
@@ -108,8 +108,8 @@ TestArr = {}
         local function execution(list, value, expectedResult, expectedIndex)
             local result, index = __.arr:inArray(list, value)
             
-            lu.assertEquals(result, expectedResult)
-            lu.assertEquals(index, expectedIndex)
+            lu.assertEquals(expectedResult, result)
+            lu.assertEquals(expectedIndex, index)
         end
 
         execution({}, nil, false, 0)
@@ -158,7 +158,7 @@ TestArr = {}
     
             arr:maybeInitialize(list, key, value)
     
-            lu.assertEquals(arr:get(list, key), expectedValue)
+            lu.assertEquals(expectedValue, arr:get(list, key))
         end
 
         local list = {}
@@ -172,7 +172,7 @@ TestArr = {}
         local function execution(list, key, expectedOutput)
             local output = __.arr:pluck(list, key)
     
-            lu.assertEquals(output, expectedOutput)
+            lu.assertEquals(expectedOutput, output)
         end
 
         execution({}, 'test-key', {})
@@ -189,7 +189,7 @@ TestArr = {}
         local execution = function(list, key, expectedOutput)
             local arr = __.arr
             arr:remove(list, key)
-            lu.assertEquals(list, expectedOutput)
+            lu.assertEquals(expectedOutput, list)
         end
 
         execution({}, 'test', {})

--- a/tests/Support/ArrTest.lua
+++ b/tests/Support/ArrTest.lua
@@ -1,3 +1,26 @@
+-- @see testArrCanGet
+local function testArrCanGetExecution(list, key, default, expectedOutput)
+    lu.assertEquals(__.arr:get(list, key, default), expectedOutput)
+end
+
+--[[
+@covers Arr:get()
+]]
+function testArrCanGet()
+    testArrCanGetExecution({}, 'test', nil, nil)
+    testArrCanGetExecution({}, 'test', 'default', 'default')
+
+    local listWithSingleObject = {}
+    listWithSingleObject['test'] = 'test'
+    testArrCanGetExecution(listWithSingleObject, 'test', nil, 'test')
+
+    local listWithNestedKeys = {}
+    listWithNestedKeys['test-a'] = {}
+    listWithNestedKeys['test-a']['test-b'] = {}
+    listWithNestedKeys['test-a']['test-b']['test-c'] = 'test'
+    testArrCanGetExecution(listWithNestedKeys, 'test-a.test-b.test-c', nil, 'test')
+end
+
 --[[
 @covers Arr
 ]]

--- a/tests/Support/ArrTest.lua
+++ b/tests/Support/ArrTest.lua
@@ -193,6 +193,7 @@ TestArr = {}
         end
 
         execution({}, 'test', {})
+        execution({'test'}, 'test', {})
         execution({'a', 'b', 'c'}, 'a', {'b', 'c'})
         execution({1, 2, 3}, 2, {1, 3})
         execution({a = 'a', b = 'b', c = 'c'}, 'a', {a = 'a', b = 'b', c = 'c'})

--- a/tests/Support/ArrTest.lua
+++ b/tests/Support/ArrTest.lua
@@ -97,3 +97,22 @@ function testArrIsArray()
     arr:set(tableWithStringKeys, 'a.b.c', 'test')
     lu.assertIsFalse(arr:isArray(tableWithStringKeys))
 end
+
+-- @see testArrMaybeInitialize
+local function testArrMaybeInitializeExecution(list, key, value, expectedValue)
+    local arr = __.arr
+
+    arr:maybeInitialize(list, key, value)
+
+    lu.assertEquals(arr:get(list, key), expectedValue)
+end
+
+--[[
+@covers Arr:maybeInitialize()
+]]
+function testArrMaybeInitialize()
+    local list = {}
+
+    testArrMaybeInitializeExecution(list, 'test-key', 'test-value', 'test-value')
+    testArrMaybeInitializeExecution(list, 'test-key', 'test-value-again', 'test-value')
+end

--- a/tests/Support/ArrTest.lua
+++ b/tests/Support/ArrTest.lua
@@ -57,6 +57,31 @@ function testArrCanImplodeWithNonList()
 end
 
 --[[
+@covers Arr:set()
+]]
+function testArrCanSet()
+    local arr = __.arr
+
+    local list = {}
+    list['a'] = {}
+    list['a']['b'] = 'test-initial'
+
+    -- sanity checks to make sure the list is consistent
+    lu.assertEquals(arr:get(list, 'a.b'), 'test-initial')
+    lu.assertIsNil(arr:get(list, 'a.c'))
+    lu.assertIsNil(arr:get(list, 'x.y.z'))
+
+    -- sets a couple of properties
+    arr:set(list, 'a.c', 'test-with-set')
+    arr:set(list, 'x.y.z', 'test-with-three-levels')
+
+    -- checks if the property 
+    lu.assertEquals(arr:get(list, 'a.c'), 'test-with-set')
+    lu.assertEquals(arr:get(list, 'x.y.z'), 'test-with-three-levels')
+    lu.assertEquals(arr:get(list, 'a.b'), 'test-initial')
+end
+
+--[[
 @covers Arr:isArray()
 ]]
 function testArrIsArray()
@@ -67,4 +92,8 @@ function testArrIsArray()
     lu.assertIsFalse(arr:isArray(1))
     lu.assertIsFalse(arr:isArray('a'))
     lu.assertIsFalse(arr:isArray(arr))
+
+    local tableWithStringKeys = {}
+    arr:set(tableWithStringKeys, 'a.b.c', 'test')
+    lu.assertIsFalse(arr:isArray(tableWithStringKeys))
 end

--- a/tests/Support/ArrTest.lua
+++ b/tests/Support/ArrTest.lua
@@ -1,212 +1,186 @@
--- @see testArrCanGet
-local function testArrCanGetExecution(list, key, default, expectedOutput)
-    lu.assertEquals(__.arr:get(list, key, default), expectedOutput)
-end
+TestArr = {}
+    -- @covers Arr:get()
+    function TestArr:testCanGet()
+        local function execution(list, key, default, expectedOutput)
+            lu.assertEquals(__.arr:get(list, key, default), expectedOutput)
+        end
 
---[[
-@covers Arr:get()
-]]
-function testArrCanGet()
-    testArrCanGetExecution({}, 'test', nil, nil)
-    testArrCanGetExecution({}, 'test', 'default', 'default')
+        execution({}, 'test', nil, nil)
+        execution({}, 'test', 'default', 'default')
 
-    local listWithSingleObject = {}
-    listWithSingleObject['test'] = 'test'
-    testArrCanGetExecution(listWithSingleObject, 'test', nil, 'test')
+        local listWithSingleObject = {}
+        listWithSingleObject['test'] = 'test'
+        execution(listWithSingleObject, 'test', nil, 'test')
 
-    local listWithNestedKeys = {}
-    listWithNestedKeys['test-a'] = {}
-    listWithNestedKeys['test-a']['test-b'] = {}
-    listWithNestedKeys['test-a']['test-b']['test-c'] = 'test'
-    testArrCanGetExecution(listWithNestedKeys, 'test-a.test-b.test-c', nil, 'test')
-end
-
---[[
-@covers Arr
-]]
-function testArrCanGetInstance()
-    local arr = __.arr
-
-    lu.assertNotIsNil(arr)
-end
-
---[[
-@covers Arr:implode()
-]]
-function testArrCanImplode()
-    local arr = __.arr
-
-    local delimiter = ','
-    local list = {'a', 'b', 'c'}
-
-    local result = arr:implode(delimiter, list)
-
-    lu.assertEquals(result, 'a,b,c')
-end
-
---[[
-@covers Arr:implode()
-]]
-function testArrCanImplodeWithNonList()
-    local arr = __.arr
-
-    local text = 'test'
-    local result = arr:implode(',', text)
-
-    lu.assertEquals(result, text)
-end
-
--- @see testArrCanInsertNotInArray
-local function testArrCanInsertNotInArrayExecution(list, value, expectedBooleanResult, expectedListResult)
-    local booleanResult = __.arr:insertNotInArray(list, value)
-
-    lu.assertEquals(booleanResult, expectedBooleanResult)
-    lu.assertEquals(list, expectedListResult)
-end
-
---[[
-@covers Arr:insertNotInArray()
-]]
-function testArrCanInsertNotInArray()
-    testArrCanInsertNotInArrayExecution('a', 'a', false, 'a')
-    testArrCanInsertNotInArrayExecution({}, 'a', true, {'a'})
-    testArrCanInsertNotInArrayExecution({'a'}, 'a', false, {'a'})
-    testArrCanInsertNotInArrayExecution({'a'}, 'b', true, {'a', 'b'})
-end
-
--- @see testArrCanMap
-local function testArrCanMapExecution(list, expectedOutput)
-    local arr = __.arr
-
-    local results = __.arr:map(list, function (val, i)
-        return val .. '-' .. i
-    end)
-
-    lu.assertEquals(results, expectedOutput)
-end
-
---[[
-@covers Arr:map()
-]]
-function testArrCanMap()
-    testArrCanMapExecution({}, {})
-    testArrCanMapExecution({'test', 'test', 'test'}, {'test-1', 'test-2', 'test-3'})
-    testArrCanMapExecution({['a'] = 'a', ['b'] = 'b', ['c'] = 'c'}, {['a'] = 'a-a', ['b'] = 'b-b', ['c'] = 'c-c'})
-end
-
---[[
-@covers Arr:set()
-]]
-function testArrCanSet()
-    local arr = __.arr
-
-    local list = {}
-    list['a'] = {}
-    list['a']['b'] = 'test-initial'
-
-    -- sanity checks to make sure the list is consistent
-    lu.assertEquals(arr:get(list, 'a.b'), 'test-initial')
-    lu.assertIsNil(arr:get(list, 'a.c'))
-    lu.assertIsNil(arr:get(list, 'x.y.z'))
-
-    -- sets a couple of properties
-    arr:set(list, 'a.c', 'test-with-set')
-    arr:set(list, 'x.y.z', 'test-with-three-levels')
-
-    -- checks if the property 
-    lu.assertEquals(arr:get(list, 'a.c'), 'test-with-set')
-    lu.assertEquals(arr:get(list, 'x.y.z'), 'test-with-three-levels')
-    lu.assertEquals(arr:get(list, 'a.b'), 'test-initial')
-end
-
--- @see testArrInArray
-local function testArrInArrayExecution(list, value, expectedResult, expectedIndex)
-    local result, index = __.arr:inArray(list, value)
-    
-    lu.assertEquals(result, expectedResult)
-    lu.assertEquals(index, expectedIndex)
-end
-
---[[
-@covers Arr:inArray()
-]]
-function testArrInArray()
-    testArrInArrayExecution({}, nil, false, 0)
-    testArrInArrayExecution({'a', 'b', 'c'}, 'd', false, 0)
-    testArrInArrayExecution({'a', 'b', 'c'}, 'a', true, 1)
-    testArrInArrayExecution({'a', 'b', 'c'}, 'c', true, 3)
-    testArrInArrayExecution({a = 'a', b = 'b', c = 'c'}, 'c', true, 'c')
-
-    local ComparableObject = {}
-    ComparableObject.__index = ComparableObject
-    ComparableObject.__ = self
-    function ComparableObject:new(value)
-        local self = setmetatable({}, ComparableObject)
-        self.value = value
-        return self
+        local listWithNestedKeys = {}
+        listWithNestedKeys['test-a'] = {}
+        listWithNestedKeys['test-a']['test-b'] = {}
+        listWithNestedKeys['test-a']['test-b']['test-c'] = 'test'
+        execution(listWithNestedKeys, 'test-a.test-b.test-c', nil, 'test')
     end
-    function ComparableObject:__eq(object) return self.value == object.value end
 
-    local objectA = ComparableObject:new('test-object-a')
-    local objectB = ComparableObject:new('test-object-b')
-    local objectC = ComparableObject:new('test-object-c')
+    -- @covers Arr
+    function TestArr:testCanGetInstance()
+        local arr = __.arr
 
-    testArrInArrayExecution({objectA, objectB}, objectC, false, 0)
-    testArrInArrayExecution({objectA, objectB}, objectB, true, 2)
-end
+        lu.assertNotIsNil(arr)
+    end
 
---[[
-@covers Arr:isArray()
-]]
-function testArrIsArray()
-    local arr = __.arr
+    -- @covers Arr:implode()
+    function TestArr:testCanImplode()
+        local arr = __.arr
 
-    lu.assertIsTrue(arr:isArray({'a', 'b', 'c'}))
+        local delimiter = ','
+        local list = {'a', 'b', 'c'}
 
-    lu.assertIsFalse(arr:isArray(1))
-    lu.assertIsFalse(arr:isArray('a'))
-    lu.assertIsFalse(arr:isArray(arr))
+        local result = arr:implode(delimiter, list)
 
-    local tableWithStringKeys = {}
-    arr:set(tableWithStringKeys, 'a.b.c', 'test')
-    lu.assertIsFalse(arr:isArray(tableWithStringKeys))
-end
+        lu.assertEquals(result, 'a,b,c')
+    end
 
--- @see testArrMaybeInitialize
-local function testArrMaybeInitializeExecution(list, key, value, expectedValue)
-    local arr = __.arr
+    -- @covers Arr:implode()
+    function TestArr:testCanImplodeWithNonList()
+        local arr = __.arr
 
-    arr:maybeInitialize(list, key, value)
+        local text = 'test'
+        local result = arr:implode(',', text)
 
-    lu.assertEquals(arr:get(list, key), expectedValue)
-end
+        lu.assertEquals(result, text)
+    end
 
---[[
-@covers Arr:maybeInitialize()
-]]
-function testArrMaybeInitialize()
-    local list = {}
+    -- @covers Arr:insertNotInArray()
+    function TestArr:testCanInsertNotInArray()
+        local function execution(list, value, expectedBooleanResult, expectedListResult)
+            local booleanResult = __.arr:insertNotInArray(list, value)
+    
+            lu.assertEquals(booleanResult, expectedBooleanResult)
+            lu.assertEquals(list, expectedListResult)
+        end
 
-    testArrMaybeInitializeExecution(list, 'test-key', 'test-value', 'test-value')
-    testArrMaybeInitializeExecution(list, 'test-key', 'test-value-again', 'test-value')
-end
+        execution('a', 'a', false, 'a')
+        execution({}, 'a', true, {'a'})
+        execution({'a'}, 'a', false, {'a'})
+        execution({'a'}, 'b', true, {'a', 'b'})
+    end
 
--- @see testArrPluck
-local function testArrPluckExecution(list, key, expectedOutput)
-    local output = __.arr:pluck(list, key)
+    -- @covers Arr:map()
+    function TestArr:testCanMap()
+        local function execution(list, expectedOutput)
+            local arr = __.arr
+    
+            local results = __.arr:map(list, function (val, i)
+                return val .. '-' .. i
+            end)
+    
+            lu.assertEquals(results, expectedOutput)
+        end
 
-    lu.assertEquals(output, expectedOutput)
-end
+        execution({}, {})
+        execution({'test', 'test', 'test'}, {'test-1', 'test-2', 'test-3'})
+        execution({['a'] = 'a', ['b'] = 'b', ['c'] = 'c'}, {['a'] = 'a-a', ['b'] = 'b-b', ['c'] = 'c-c'})
+    end
 
---[[
-@covers Arr:pluck()
-]]
-function testArrPluck()
-    testArrPluckExecution({}, 'test-key', {})
+    -- @covers Arr:set()
+    function TestArr:testCanSet()
+        local arr = __.arr
 
-    local objectA = {['test-key'] = {['test-nested-key'] = 'test-value'}}
-    local objectB = {['test-key'] = nil}
-    local objectC = {}
+        local list = {}
+        list['a'] = {}
+        list['a']['b'] = 'test-initial'
 
-    testArrPluckExecution({objectA, objectB, objectC}, 'test-key.test-nested-key', {'test-value'})
-end
+        -- sanity checks to make sure the list is consistent
+        lu.assertEquals(arr:get(list, 'a.b'), 'test-initial')
+        lu.assertIsNil(arr:get(list, 'a.c'))
+        lu.assertIsNil(arr:get(list, 'x.y.z'))
+
+        -- sets a couple of properties
+        arr:set(list, 'a.c', 'test-with-set')
+        arr:set(list, 'x.y.z', 'test-with-three-levels')
+
+        -- checks if the property 
+        lu.assertEquals(arr:get(list, 'a.c'), 'test-with-set')
+        lu.assertEquals(arr:get(list, 'x.y.z'), 'test-with-three-levels')
+        lu.assertEquals(arr:get(list, 'a.b'), 'test-initial')
+    end
+
+    -- @covers Arr:inArray()
+    function TestArr:testInArray()
+        local function execution(list, value, expectedResult, expectedIndex)
+            local result, index = __.arr:inArray(list, value)
+            
+            lu.assertEquals(result, expectedResult)
+            lu.assertEquals(index, expectedIndex)
+        end
+
+        execution({}, nil, false, 0)
+        execution({'a', 'b', 'c'}, 'd', false, 0)
+        execution({'a', 'b', 'c'}, 'a', true, 1)
+        execution({'a', 'b', 'c'}, 'c', true, 3)
+        execution({a = 'a', b = 'b', c = 'c'}, 'c', true, 'c')
+
+        local ComparableObject = {}
+        ComparableObject.__index = ComparableObject
+        ComparableObject.__ = self
+        function ComparableObject:new(value)
+            local self = setmetatable({}, ComparableObject)
+            self.value = value
+            return self
+        end
+        function ComparableObject:__eq(object) return self.value == object.value end
+
+        local objectA = ComparableObject:new('test-object-a')
+        local objectB = ComparableObject:new('test-object-b')
+        local objectC = ComparableObject:new('test-object-c')
+
+        execution({objectA, objectB}, objectC, false, 0)
+        execution({objectA, objectB}, objectB, true, 2)
+    end
+
+    -- @covers Arr:isArray()
+    function TestArr:testIsArray()
+        local arr = __.arr
+
+        lu.assertIsTrue(arr:isArray({'a', 'b', 'c'}))
+
+        lu.assertIsFalse(arr:isArray(1))
+        lu.assertIsFalse(arr:isArray('a'))
+        lu.assertIsFalse(arr:isArray(arr))
+
+        local tableWithStringKeys = {}
+        arr:set(tableWithStringKeys, 'a.b.c', 'test')
+        lu.assertIsFalse(arr:isArray(tableWithStringKeys))
+    end
+
+    -- @covers Arr:maybeInitialize()
+    function TestArr:testMaybeInitialize()
+        local function execution(list, key, value, expectedValue)
+            local arr = __.arr
+    
+            arr:maybeInitialize(list, key, value)
+    
+            lu.assertEquals(arr:get(list, key), expectedValue)
+        end
+
+        local list = {}
+
+        execution(list, 'test-key', 'test-value', 'test-value')
+        execution(list, 'test-key', 'test-value-again', 'test-value')
+    end
+
+    -- @covers Arr:pluck()
+    function TestArr:testPluck()
+        local function execution(list, key, expectedOutput)
+            local output = __.arr:pluck(list, key)
+    
+            lu.assertEquals(output, expectedOutput)
+        end
+
+        execution({}, 'test-key', {})
+
+        local objectA = {['test-key'] = {['test-nested-key'] = 'test-value'}}
+        local objectB = {['test-key'] = nil}
+        local objectC = {}
+
+        execution({objectA, objectB, objectC}, 'test-key.test-nested-key', {'test-value'})
+    end
+-- end of TestArr

--- a/tests/Support/ArrTest.lua
+++ b/tests/Support/ArrTest.lua
@@ -56,8 +56,8 @@ function testArrCanImplodeWithNonList()
     lu.assertEquals(result, text)
 end
 
--- @see testCanInsertNotInArray
-local function testCanInsertNotInArrayExecution(list, value, expectedBooleanResult, expectedListResult)
+-- @see testArrCanInsertNotInArray
+local function testArrCanInsertNotInArrayExecution(list, value, expectedBooleanResult, expectedListResult)
     local booleanResult = __.arr:insertNotInArray(list, value)
 
     lu.assertEquals(booleanResult, expectedBooleanResult)
@@ -67,11 +67,11 @@ end
 --[[
 @covers Arr:insertNotInArray()
 ]]
-function testCanInsertNotInArray()
-    testCanInsertNotInArrayExecution('a', 'a', false, 'a')
-    testCanInsertNotInArrayExecution({}, 'a', true, {'a'})
-    testCanInsertNotInArrayExecution({'a'}, 'a', false, {'a'})
-    testCanInsertNotInArrayExecution({'a'}, 'b', true, {'a', 'b'})
+function testArrCanInsertNotInArray()
+    testArrCanInsertNotInArrayExecution('a', 'a', false, 'a')
+    testArrCanInsertNotInArrayExecution({}, 'a', true, {'a'})
+    testArrCanInsertNotInArrayExecution({'a'}, 'a', false, {'a'})
+    testArrCanInsertNotInArrayExecution({'a'}, 'b', true, {'a', 'b'})
 end
 
 -- @see testArrCanMap
@@ -189,4 +189,24 @@ function testArrMaybeInitialize()
 
     testArrMaybeInitializeExecution(list, 'test-key', 'test-value', 'test-value')
     testArrMaybeInitializeExecution(list, 'test-key', 'test-value-again', 'test-value')
+end
+
+-- @see testArrPluck
+local function testArrPluckExecution(list, key, expectedOutput)
+    local output = __.arr:pluck(list, key)
+
+    lu.assertEquals(output, expectedOutput)
+end
+
+--[[
+@covers Arr:pluck()
+]]
+function testArrPluck()
+    testArrPluckExecution({}, 'test-key', {})
+
+    local objectA = {['test-key'] = {['test-nested-key'] = 'test-value'}}
+    local objectB = {['test-key'] = nil}
+    local objectC = {}
+
+    testArrPluckExecution({objectA, objectB, objectC}, 'test-key.test-nested-key', {'test-value'})
 end

--- a/tests/Support/StrTest.lua
+++ b/tests/Support/StrTest.lua
@@ -2,7 +2,7 @@ TestStr = {}
     -- @covers Str:split()
     function TestStr:testCanSplit()
         local function execution(value, separator, expectedOutput)
-            lu.assertEquals(__.str:split(value, separator), expectedOutput)
+            lu.assertEquals(expectedOutput, __.str:split(value, separator))
         end
 
         execution('', '.', {})

--- a/tests/Support/StrTest.lua
+++ b/tests/Support/StrTest.lua
@@ -1,0 +1,13 @@
+-- @see testStrCanSplit
+local function testStrCanSplitExecution(value, separator, expectedOutput)
+    lu.assertEquals(__.str:split(value, separator), expectedOutput)
+end
+
+--[[
+@covers Str:split()
+]]
+function testStrCanSplit()
+    testStrCanSplitExecution('', '.', {})
+    testStrCanSplitExecution('test', '.', {'test'})
+    testStrCanSplitExecution('test-a.test-b.test-c', '.', {'test-a', 'test-b', 'test-c'})
+end

--- a/tests/Support/StrTest.lua
+++ b/tests/Support/StrTest.lua
@@ -1,13 +1,12 @@
--- @see testStrCanSplit
-local function testStrCanSplitExecution(value, separator, expectedOutput)
-    lu.assertEquals(__.str:split(value, separator), expectedOutput)
-end
+TestStr = {}
+    -- @covers Str:split()
+    function TestStr:testCanSplit()
+        local function execution(value, separator, expectedOutput)
+            lu.assertEquals(__.str:split(value, separator), expectedOutput)
+        end
 
---[[
-@covers Str:split()
-]]
-function testStrCanSplit()
-    testStrCanSplitExecution('', '.', {})
-    testStrCanSplitExecution('test', '.', {'test'})
-    testStrCanSplitExecution('test-a.test-b.test-c', '.', {'test-a', 'test-b', 'test-c'})
-end
+        execution('', '.', {})
+        execution('test', '.', {'test'})
+        execution('test-a.test-b.test-c', '.', {'test-a', 'test-b', 'test-c'})
+    end
+-- end of TestStr

--- a/tests/unit.lua
+++ b/tests/unit.lua
@@ -1,7 +1,10 @@
 lu = require('luaunit')
 
 dofile('./dist/stormwind-library.lua')
-__ = StormwindLibrary_v0_0_4.new()
+function newLibrary() return StormwindLibrary_v0_0_6.new() end
+    __ = newLibrary()
+
+dofile('./tests/Core/FactoryTest.lua')
 
 dofile('./tests/Facades/TargetTest.lua')
 

--- a/tests/unit.lua
+++ b/tests/unit.lua
@@ -13,4 +13,6 @@ dofile('./tests/Models/MacroTest.lua')
 dofile('./tests/Support/ArrTest.lua')
 dofile('./tests/Support/StrTest.lua')
 
+lu.ORDER_ACTUAL_EXPECTED=false
+
 os.exit(lu.LuaUnit.run())

--- a/tests/unit.lua
+++ b/tests/unit.lua
@@ -8,6 +8,9 @@ dofile('./tests/Core/FactoryTest.lua')
 
 dofile('./tests/Facades/TargetTest.lua')
 
+dofile('./tests/Models/MacroTest.lua')
+
 dofile('./tests/Support/ArrTest.lua')
+dofile('./tests/Support/StrTest.lua')
 
 os.exit(lu.LuaUnit.run())


### PR DESCRIPTION
# Pending items

- [x] Group test methods
- [x] Indent class methods like what's done in the test classes, example:
    ```lua
    local TargetList = {}
        TargetList.__index = TargetList

        --[[
        Target list constructor.
        ]]
        function TargetList.__construct(listName)
            local self = setmetatable({}, TargetList)

        -- ...
    -- end of TargetList 
    ```
- [x] Invert actual and expected assertions with `lu.ORDER_ACTUAL_EXPECTED=false`