### PR TITLE
Add the CommandsHandler class

### DIFF
--- a/compiler/build.js
+++ b/compiler/build.js
@@ -108,7 +108,7 @@ if (${library}) then return end
 ${library} = {}
 ${library}.__index = ${library}
 
-function ${library}.new()
+function ${library}.new(props)
     local self = setmetatable({}, ${library})
     ${this.fileContent}
     return self

--- a/documentation/docs/changelog.md
+++ b/documentation/docs/changelog.md
@@ -2,6 +2,8 @@
 
 ## 2024.mm.yy - version 0.0.7-alpha
 
+* Add the CommandsHandler class to allow addons to register commands
+
 ## 2024.03.16 - version 0.0.6-alpha
 
 * Add the Str support class

--- a/documentation/docs/changelog.md
+++ b/documentation/docs/changelog.md
@@ -3,6 +3,7 @@
 ## 2024.mm.yy - version 0.0.7-alpha
 
 * Add the CommandsHandler class to allow addons to register commands
+* Allow passing addon properties to the library
 
 ## 2024.03.16 - version 0.0.6-alpha
 

--- a/documentation/docs/resources/commands/_category_.json
+++ b/documentation/docs/resources/commands/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "Commands",
+  "link": {
+    "type": "generated-index",
+    "description": "Resources for easy slash command register for addons."
+  }
+}

--- a/documentation/docs/resources/commands/command-handler.md
+++ b/documentation/docs/resources/commands/command-handler.md
@@ -24,12 +24,17 @@ library register the command during its initialization.
 point.
 1. After that, each `add(command)` call will map its operation and callback.
 1. When the command is executed in game, the library will have its callback
-triggered along with the arguments. The first argument is considered the 
-operation, so it will determine the proper callback to trigger. This 
-callback is the one exposed by the command object.
-
-:::warning @TODO
-
-* Describe how it handles the other arguments
-
-:::
+triggered along with the argument, which is broken by spaces.
+    * When a command is executed in the game, everything after the command 
+    itself becomes the argument. Example: `/myCommand arg1 arg2 arg3` will 
+    trigger the callback with `arg1 arg2 arg3`.
+    * The Stormwind Library command handler was designed to forward the 
+    arguments like an operating system console where arguments
+    are separated by blank spaces. Arguments that must contain spaces can
+    be wrapped by `"` or `'`. Example: `/myCommand arg1 "arg2 arg3"` will 
+    result in two arguments `{'arg1', 'arg2 arg3'}`.
+1. This list of arguments are divided, and the first argument is considered 
+the command **operation**, so it will determine the proper callback to 
+trigger in the addon. This callback is the one exposed by the command 
+object.
+1. The other arguments (if any) are passed to the operation callback.

--- a/documentation/docs/resources/commands/command-handler.md
+++ b/documentation/docs/resources/commands/command-handler.md
@@ -1,0 +1,35 @@
+---
+sidebar_position: 3
+title: Command Handler
+---
+
+The command handler is a class that intercepts all commands registered by an
+addon. That allows the library to parse arguments and trigger the 
+registered callbacks.
+
+As mentioned in the [overview](overview), one of the motivations behind the
+commands structure is to allow commands to behave as objects, and that's 
+possible leaving all the command conditionals, parsing, etc, to the handler,
+requiring commands to just expose a callback expecting the desired 
+arguments.
+
+* See how to register commands [here](command)
+
+## How it works
+
+1. When an addon initializes its library instance, it can pass a property in
+the constructor representing the addon main command. That will make the 
+library register the command during its initialization.
+1. The library registers the command associating its own callback at this 
+point.
+1. After that, each `add(command)` call will map its operation and callback.
+1. When the command is executed in game, the library will have its callback
+triggered along with the arguments. The first argument is considered the 
+operation, so it will determine the proper callback to trigger. This 
+callback is the one exposed by the command object.
+
+:::warning @TODO
+
+* Describe how it handles the other arguments
+
+:::

--- a/documentation/docs/resources/commands/command-handler.md
+++ b/documentation/docs/resources/commands/command-handler.md
@@ -22,7 +22,8 @@ the constructor representing the addon main command. That will make the
 library register the command during its initialization.
 1. The library registers the command associating its own callback at this 
 point.
-1. After that, each `add(command)` call will map its operation and callback.
+1. After that, each `add(command)` call will map its operation and the command
+itself.
 1. When the command is executed in game, the library will have its callback
 triggered along with the argument, which is broken by spaces.
     * When a command is executed in the game, everything after the command 

--- a/documentation/docs/resources/commands/command.md
+++ b/documentation/docs/resources/commands/command.md
@@ -1,0 +1,46 @@
+---
+sidebar_position: 2
+title: Command
+---
+
+The command object is a simple DTO object that can also house the callback
+if the addon has a good class structure.
+
+It basically holds the required information to register a slash command in
+the game:
+
+1. **Operation:** the `setOperation(operation)` expects a string operation
+name which will be the one used by the library to forward the command 
+execution
+1. **Callback:** the `setCallback(callback)` expects a function that will be
+executed when the library captures a command.
+
+:::warning @TODO
+
+* Complete this guide with the parameters list.
+* Complete this guide with the command description.
+
+:::
+
+## Example
+
+Imagine an addon that needs to register a **clear** command that will clear
+any inner list. The addon holds the library instance in a property called
+`library`.
+
+```lua
+-- instantiates a command using the library factory
+local command = CustomAddon.library:new('Command')
+
+function command:commandExecution()
+    -- execute any addon code here
+    print('command executed')
+end
+
+command
+    :setOperation('clear')
+    :setCallback(command.commandExecution)
+
+-- registers the command in the library
+CustomAddon.library.commands:add(command)
+```

--- a/documentation/docs/resources/commands/command.md
+++ b/documentation/docs/resources/commands/command.md
@@ -15,12 +15,8 @@ execution
 1. **Callback:** the `setCallback(callback)` expects a function that will be
 executed when the library captures a command. This function may expect
 parameters that will be parsed by the command handler.
-
-:::warning @TODO
-
-* Complete this guide with the command description.
-
-:::
+1. **Description:** optional property set with `setDescription(description)`
+that will also store additional information for that command.
 
 ## Example
 
@@ -38,6 +34,7 @@ function command:commandExecution(arg1, arg2)
 end
 
 command
+    :setDescription('Clears the addon cache')
     :setOperation('clear')
     :setCallback(command.commandExecution)
 

--- a/documentation/docs/resources/commands/command.md
+++ b/documentation/docs/resources/commands/command.md
@@ -20,11 +20,32 @@ that will also store additional information for that command. When defined,
 the [default help operation](commands-handler#the-help-operation) will print
 it after the operation name.
 
+## Requirements
+
+In order to add commands, the library must be initialized with the `command`
+property. After that, every command instance created in the example below will
+be registered as an operation that will be executed by the registered command.
+
+Read the [Addon Properties](../core/addon-properties) documentation for more
+reference.
+
 ## Example
 
 Imagine an addon that needs to register a **clear** command that will clear
-any inner list. The addon holds the library instance in a property called
-`library`.
+a table. Something like a cache clear. The addon holds the library instance
+in a property called `library`.
+
+First, the library must be initialized with the `command` property:
+
+```lua
+CustomAddon.library = StormwindLibrary.new({
+  command = 'myAddon',
+  -- other properties here
+})
+```
+
+After that, it's possible to register any other commands, called operations,
+as necessary.
 
 ```lua
 -- instantiates a command using the library factory
@@ -42,4 +63,10 @@ command
 
 -- registers the command in the library
 CustomAddon.library.commands:add(command)
+```
+
+In game, running the following line in the chat will execute the command:
+
+```shell
+/myAddon clear
 ```

--- a/documentation/docs/resources/commands/command.md
+++ b/documentation/docs/resources/commands/command.md
@@ -13,11 +13,11 @@ the game:
 name which will be the one used by the library to forward the command 
 execution
 1. **Callback:** the `setCallback(callback)` expects a function that will be
-executed when the library captures a command.
+executed when the library captures a command. This function may expect
+parameters that will be parsed by the command handler.
 
 :::warning @TODO
 
-* Complete this guide with the parameters list.
 * Complete this guide with the command description.
 
 :::
@@ -32,9 +32,9 @@ any inner list. The addon holds the library instance in a property called
 -- instantiates a command using the library factory
 local command = CustomAddon.library:new('Command')
 
-function command:commandExecution()
+function command:commandExecution(arg1, arg2)
     -- execute any addon code here
-    print('command executed')
+    print('command executed with arg1 = ' .. arg1 .. ', and arg2 = ' .. arg2)
 end
 
 command

--- a/documentation/docs/resources/commands/command.md
+++ b/documentation/docs/resources/commands/command.md
@@ -11,12 +11,14 @@ the game:
 
 1. **Operation:** the `setOperation(operation)` expects a string operation
 name which will be the one used by the library to forward the command 
-execution
+execution.
 1. **Callback:** the `setCallback(callback)` expects a function that will be
 executed when the library captures a command. This function may expect
-parameters that will be parsed by the command handler.
+parameters that will be parsed by the commands handler.
 1. **Description:** optional property set with `setDescription(description)`
-that will also store additional information for that command.
+that will also store additional information for that command. When defined,
+the [default help operation](commands-handler#the-help-operation) will print
+it after the operation name.
 
 ## Example
 

--- a/documentation/docs/resources/commands/commands-handler.md
+++ b/documentation/docs/resources/commands/commands-handler.md
@@ -1,9 +1,9 @@
 ---
 sidebar_position: 3
-title: Command Handler
+title: Commands Handler
 ---
 
-The command handler is a class that intercepts all commands registered by an
+The commands handler is a class that intercepts all commands registered by an
 addon. That allows the library to parse arguments and trigger the 
 registered callbacks.
 
@@ -29,7 +29,7 @@ triggered along with the argument, which is broken by spaces.
     * When a command is executed in the game, everything after the command 
     itself becomes the argument. Example: `/myCommand arg1 arg2 arg3` will 
     trigger the callback with `arg1 arg2 arg3`.
-    * The Stormwind Library command handler was designed to forward the 
+    * The Stormwind Library commands handler was designed to forward the 
     arguments like an operating system console where arguments
     are separated by blank spaces. Arguments that must contain spaces can
     be wrapped by `"` or `'`. Example: `/myCommand arg1 "arg2 arg3"` will 
@@ -39,3 +39,12 @@ the command **operation**, so it will determine the proper callback to
 trigger in the addon. This callback is the one exposed by the command 
 object.
 1. The other arguments (if any) are passed to the operation callback.
+
+## The help operation
+
+By default, the commands handler offers a **help** operation that behaves as
+a normal command. It basically prints all the available operations (except for
+the help itself) along with their descriptions.
+
+Addons that must need to override the help operation, simply create a command
+and add it normally, so the default one will be replaced.

--- a/documentation/docs/resources/commands/overview.md
+++ b/documentation/docs/resources/commands/overview.md
@@ -36,12 +36,9 @@ the first argument is considered the operation, which means something like
 the real command inside the addon. As an example `/myAddonCommand show` and
 `/myAddonCommand hide` are commands with two different operations: **show**
 and **hide**
-
-:::warning @TODO
-
-Complete this guide with the parameters list.
-
-:::
+    * Still, a command callback may accept parameters, so a command like
+    `/myAddonCommand show simpleUi darkMode` will call the **show** callback
+    passing `simpleUi` and `darkMode` arguments
 
 If the addon can handle commands in the proposed way, then it can use the
 resources below to register, listen and trigger callbacks for slash 

--- a/documentation/docs/resources/commands/overview.md
+++ b/documentation/docs/resources/commands/overview.md
@@ -45,4 +45,4 @@ resources below to register, listen and trigger callbacks for slash
 commands.
 
 * [Creating and registering a command](command)
-* [How the command handler works](command-handler)
+* [How the commands handler works](commands-handler)

--- a/documentation/docs/resources/commands/overview.md
+++ b/documentation/docs/resources/commands/overview.md
@@ -1,0 +1,51 @@
+---
+sidebar_position: 1
+title: Overview
+---
+
+Slash commands in World of Warcraft are executed in the chat box that can
+execute lots of things for a character as well as for the UI.
+
+Examples of slash commands:
+
+* `/m` opens the macro window
+* `/dance` puts the character to dance
+* `/logout` logs the character off
+
+There are lots of native commands, and addons can introduce their own.
+
+## Stormwind Library commands
+
+It's very easy to add new slash commands to the game and you can do that 
+with a couple of code lines.
+
+The Stormwind Library offers a small structure to add commands in a more OOP
+approach, which means you can wrap a command in a Lua class in case its 
+complex enough to be handled by a procedural script.
+
+That said, if an addon needs to use the library commands resources, it must
+adhere to a few rules. Otherwise, the addon can "manually" introduce 
+commands in the traditional way.
+
+1. **Single command name:** the library allows only a single command per 
+addon. Which means the addon can't register `/myAddonCommand` and
+`/myAddonAnotherCommand`, instead, it must use the concept of command 
+operations
+2. **One callback per operation:** considering a single command per addon,
+the first argument is considered the operation, which means something like
+the real command inside the addon. As an example `/myAddonCommand show` and
+`/myAddonCommand hide` are commands with two different operations: **show**
+and **hide**
+
+:::warning @TODO
+
+Complete this guide with the parameters list.
+
+:::
+
+If the addon can handle commands in the proposed way, then it can use the
+resources below to register, listen and trigger callbacks for slash 
+commands.
+
+* [Creating and registering a command](command)
+* [How the command handler works](command-handler)

--- a/documentation/docs/resources/commands/overview.md
+++ b/documentation/docs/resources/commands/overview.md
@@ -46,3 +46,24 @@ commands.
 
 * [Creating and registering a command](command)
 * [How the commands handler works](commands-handler)
+
+## Current limitations
+
+The current command structure has a few limitations that developers need to
+be aware. These limitations can be covered in the future depending on their
+demand and more clarity on how this structure is being used:
+
+1. **Commands must have an operation:** a command can't be created without
+the operation, meaning that `/myAddonCommand` with no arguments won't have
+any effects and won't forward to the addon callbacks.
+    * For cases where the addon needs only one single command, prefer to use
+    a default operation representing what the command opens or runs, examples:
+        * `/myAddonCommand show`
+        * `/myAddonCommand config`
+        * `/myAddonCommand start`
+1. **Arguments can't escape quotes:** when calling commands handled by the
+Stormwind Library, arguments are separated by a space (` `) meaning that
+`/myAddonCommand operation arg1 arg2` will call the operation passing both
+arguments as two Lua variables and it also allows wrapping strings with
+spaces in `""` or `''`. However, until the current version, it's not possible
+to escape quotes in a way that the argument can't contain those characters.

--- a/documentation/docs/resources/core/addon-properties.md
+++ b/documentation/docs/resources/core/addon-properties.md
@@ -1,0 +1,45 @@
+# Addon Properties
+
+When the library is initialized, addons can pass its properties to
+improve how it handles its resources.
+
+In the example below, `MyAddon` is the addon main table and `__` is
+the library reference. Please, remember that the library class must
+carry its version to avoid conflicts, but for the sake of simplicity,
+it's simply called `StormwindLibrary`.
+
+```lua
+MyAddon.__ = StormwindLibrary.new({
+  command = 'myAddon',
+  name    = 'My Custom Addon',
+})
+```
+
+Once initialized, these properties can be accessed in the library's
+property called `addon`. The code below will print "My Custom Addon".
+
+```lua
+print(MyAddon.__.addon.name)
+```
+
+## Available properties
+
+The following sections list the available properties and their effect
+on the library. See the first example in this article on how to pass
+the addon properties and each subtitle below represents a table index,
+so when showing `command` for example, it means passing a table with
+`{command = 'myAddon'}` when calling `new()` for a new library instance.
+
+Some parameters are **optional** and some are **required**.
+
+### command
+
+* **Optional**
+* **Effect:** when initialized, the library will register a command
+that can be executed in game. Please, read the
+[commands documentation](../commands/overview) for reference.
+
+### name
+
+* **Optional**
+* **Effect:** the library will store the addon name for multiple purposes.

--- a/documentation/docs/resources/support/arr.md
+++ b/documentation/docs/resources/support/arr.md
@@ -78,6 +78,8 @@ initialized yet.
 a given key.
 * `Arr:remove()` - Removes a value from an indexed array.
 * `Arr:set()` - Sets a value in an array using the dot notation.
+* `Arr:unpack()` - Calls the available `unpack()` method given the running 
+environment.
 
 :::tip Methods args and logic
 

--- a/src/Commands/Command.lua
+++ b/src/Commands/Command.lua
@@ -1,6 +1,15 @@
 --[[
 The command class represents a command in game that can be executed with
-/commandName
+/commandName.
+
+Commands in the Stormwind Library are structured in three parts being:
+
+1. The command name
+2. The command action
+3. The command arguments
+
+That said, a command called myAddonCommand that shows its settings screen
+in dark mode would be executed with /myAddonCommand show darkMode.
 ]]
 local Command = {}
     Command.__index = Command
@@ -12,5 +21,35 @@ local Command = {}
     ]]
     function Command.__construct()
         return setmetatable({}, Command)
+    end
+
+    --[[
+    Sets the command action.
+
+    @return self
+    ]]
+    function Command:setAction(action)
+        self.action = action
+        return self
+    end
+
+    --[[
+    Sets the command callback.
+
+    @return self
+    ]]
+    function Command:setCallback(callback)
+        self.callback = callback
+        return self
+    end
+    
+    --[[
+    Sets the command name.
+
+    @return self
+    ]]
+    function Command:setName(name)
+        self.name = name
+        return self
     end
 -- end of Command

--- a/src/Commands/Command.lua
+++ b/src/Commands/Command.lua
@@ -2,11 +2,10 @@
 The command class represents a command in game that can be executed with
 /commandName.
 
-Commands in the Stormwind Library are structured in three parts being:
+Commands in the Stormwind Library are structured in two parts being:
 
-1. The command name
-2. The command action
-3. The command arguments
+1. The command operation
+2. The command arguments
 
 That said, a command called myAddonCommand that shows its settings screen
 in dark mode would be executed with /myAddonCommand show darkMode.
@@ -24,12 +23,12 @@ local Command = {}
     end
 
     --[[
-    Sets the command action.
+    Sets the command operation.
 
     @return self
     ]]
-    function Command:setAction(action)
-        self.action = action
+    function Command:setOperation(operation)
+        self.operation = operation
         return self
     end
 
@@ -40,16 +39,6 @@ local Command = {}
     ]]
     function Command:setCallback(callback)
         self.callback = callback
-        return self
-    end
-    
-    --[[
-    Sets the command name.
-
-    @return self
-    ]]
-    function Command:setName(name)
-        self.name = name
         return self
     end
 -- end of Command

--- a/src/Commands/Command.lua
+++ b/src/Commands/Command.lua
@@ -23,6 +23,16 @@ local Command = {}
     end
 
     --[[
+    Sets the command description.
+
+    @return self
+    ]]
+    function Command:setDescription(description)
+        self.description = description
+        return self
+    end
+
+    --[[
     Sets the command operation.
 
     @return self

--- a/src/Commands/Command.lua
+++ b/src/Commands/Command.lua
@@ -1,0 +1,16 @@
+--[[
+The command class represents a command in game that can be executed with
+/commandName
+]]
+local Command = {}
+    Command.__index = Command
+    Command.__ = self
+    self:addClass('Command', Command)
+
+    --[[
+    Command constructor.
+    ]]
+    function Command.__construct()
+        return setmetatable({}, Command)
+    end
+-- end of Command

--- a/src/Commands/Command.lua
+++ b/src/Commands/Command.lua
@@ -23,6 +23,21 @@ local Command = {}
     end
 
     --[[
+    Returns a human readable help content for the command.
+
+    @treturn string
+    ]]
+    function Command:getHelpContent()
+        local content = self.operation
+
+        if self.description then
+            content = content .. ' - ' .. self.description
+        end
+
+        return content
+    end
+
+    --[[
     Sets the command description.
 
     @return self

--- a/src/Commands/CommandsHandler.lua
+++ b/src/Commands/CommandsHandler.lua
@@ -1,0 +1,18 @@
+--[[
+The commands handler provides resources for easy command registration,
+listening and triggering.
+]]
+local CommandsHandler = {}
+    CommandsHandler.__index = CommandsHandler
+    CommandsHandler.__ = self
+
+    --[[
+    Target constructor.
+    ]]
+    function CommandsHandler.__construct()
+        return setmetatable({}, CommandsHandler)
+    end
+-- end of CommandsHandler
+
+-- sets the unique library commands handler instance
+self.commands = CommandsHandler.__construct()

--- a/src/Commands/CommandsHandler.lua
+++ b/src/Commands/CommandsHandler.lua
@@ -7,12 +7,61 @@ local CommandsHandler = {}
     CommandsHandler.__ = self
 
     --[[
-    Target constructor.
+    CommandsHandler constructor.
     ]]
     function CommandsHandler.__construct()
-        return setmetatable({}, CommandsHandler)
+        local self = setmetatable({}, CommandsHandler)
+
+        self.operations = {}
+
+        return self
+    end
+
+    --[[
+    Adds a command that will be handled by the library.
+
+    The command must have an operation and a callback.
+
+    It's important to mention that calling this method with two commands
+    sharing the same operation won't stack two callbacks, but the second
+    one will replace the first.
+    ]]
+    function CommandsHandler:add(command)
+        self.operations[command.operation] = command.callback
+    end
+
+    function CommandsHandler:handle(commandArg)
+        local args = self.__.str:split(commandArg or '', ' ')
+
+        if #args < 1 then return end
+
+        -- @TODO: Parse command arguments after the operation
+        self:maybeInvokeCallback(args[1], {})
+    end
+
+    function CommandsHandler:maybeInvokeCallback(operation, args)
+        if not operation then return end
+
+        local callback = self.operations[operation]
+
+        if callback then
+            callback(unpack(args))
+        end
+    end
+
+    function CommandsHandler:register()
+        if not self.__.addon.command then return end
+
+        local lowercaseCommand = string.lower(self.__.addon.command)
+        local uppercaseCommand = string.upper(self.__.addon.command)
+
+        _G['SLASH_' .. uppercaseCommand .. '1'] = '/' .. lowercaseCommand
+        SlashCmdList[uppercaseCommand] = function (args)
+            self:handle(args)
+        end
     end
 -- end of CommandsHandler
 
 -- sets the unique library commands handler instance
 self.commands = CommandsHandler.__construct()
+self.commands:register()

--- a/src/Commands/CommandsHandler.lua
+++ b/src/Commands/CommandsHandler.lua
@@ -27,7 +27,7 @@ local CommandsHandler = {}
     one will replace the first.
     ]]
     function CommandsHandler:add(command)
-        self.operations[command.operation] = command.callback
+        self.operations[command.operation] = command
     end
 
     --[[
@@ -53,7 +53,8 @@ local CommandsHandler = {}
         -- @TODO: Call a default callback if no operation is found <2024.03.18>
         if not operation then return end
 
-        local callback = self.operations[operation]
+        local command = self.operations[operation]
+        local callback = command and command.callback or nil
 
         if callback then
             callback(table.unpack(args))

--- a/src/Commands/CommandsHandler.lua
+++ b/src/Commands/CommandsHandler.lua
@@ -49,6 +49,62 @@ local CommandsHandler = {}
         end
     end
 
+    --[[
+    This function is responsible for breaking the full argument word that's
+    sent by World of Warcraft to the command callback.
+
+    When a command is executed, everything after the command itself becomes
+    the argument. Example: /myCommand arg1 arg2 arg3 will trigger the
+    callback with "arg1 arg2 arg3".
+
+    The Stormwind Library handles events like a OS console where arguments
+    are separated by blank spaces. Arguments that must contain spaces can
+    be wrapped by " or '. Example: /myCommand arg1 "arg2 arg3" will result
+    in {'arg1', 'arg2 arg3'}.
+
+    Limitations in this method: when designed, this method meant to allow
+    escaping quotes so arguments could contain those characters. However,
+    that would add more complexity to this method and its first version is
+    focused on simplicity.
+
+    Notes: the algorithm in this method deserves improvements, or even some
+    handling with regular expression. This is something that should be
+    revisited in the future and when updated, make sure
+    TestCommandsHandler:testGetCommandsHandler() tests pass.
+    ]]
+    function CommandsHandler:parseArguments(input)
+        if not input then return {} end
+
+        local function removeQuotes(value)
+            return self.__.str:replaceAll(self.__.str:replaceAll(value, "'", ''), '"', '')
+        end
+
+        local result = {}
+        local inQuotes = false
+        local currentWord = ""
+        
+        for i = 1, #input do
+            local char = input:sub(i, i)
+            if char == '"' or char == "'" then
+                inQuotes = not inQuotes
+                currentWord = currentWord .. char
+            elseif char == " " and not inQuotes then
+                if currentWord ~= "" then
+                    table.insert(result, removeQuotes(currentWord))
+                    currentWord = ""
+                end
+            else
+                currentWord = currentWord .. char
+            end
+        end
+        
+        if currentWord ~= "" then
+            table.insert(result, removeQuotes(currentWord))
+        end
+        
+        return result
+    end
+
     function CommandsHandler:register()
         if not self.__.addon.command then return end
 

--- a/src/Commands/CommandsHandler.lua
+++ b/src/Commands/CommandsHandler.lua
@@ -104,7 +104,7 @@ local CommandsHandler = {}
         local callback = command and command.callback or nil
 
         if callback then
-            callback(table.unpack(args))
+            callback(self.__.arr:unpack(args))
         end
     end
 
@@ -182,7 +182,7 @@ local CommandsHandler = {}
         else
             -- the subset of the args table from the second element to the last
             -- represents the arguments
-            return args[1], {table.unpack(args, 2)}
+            return args[1], {self.__.arr:unpack(args, 2)}
         end
     end
 

--- a/src/Core/AddonProperties.lua
+++ b/src/Core/AddonProperties.lua
@@ -1,0 +1,12 @@
+--[[
+Sets the addon properties.
+
+Allowed properties = {
+    command: string, optional
+    name: string, optional
+}
+]]
+self.addon = {}
+
+self.addon.command = self.arr:get(props or {}, 'command')
+self.addon.name    = self.arr:get(props or {}, 'name')

--- a/src/Support/Arr.lua
+++ b/src/Support/Arr.lua
@@ -195,6 +195,23 @@ local Arr = {}
             current = current[key]
         end
     end
+
+    --[[
+    Calls the available unpack() method given the running environment.
+
+    This method is an important helper because World of Warcraft supports
+    the unpack() function but not table.unpack(). At the same time, some
+    Lua installations have no unpack() but table.unpack().
+
+    @codeCoverageIgnore this method is just a facade to the proper unpack
+                        method and won't be tested given that it's tied to
+                        the running environment
+    ]]
+    function Arr:unpack(list, i, j)
+        if unpack then return unpack(list, i, j) end
+
+        return table.unpack(list, i, j)
+    end
 -- end of Arr
 
 self.arr = Arr

--- a/src/Support/Arr.lua
+++ b/src/Support/Arr.lua
@@ -34,15 +34,7 @@ local Arr = {}
             return list
         end
 
-        local result = ""
-        local length = #list
-        for i, v in ipairs(list) do
-            result = result .. v
-            if i < length then
-                result = result .. delimiter
-            end
-        end
-        return result
+        return table.concat(list, delimiter)
     end
 
     --[[

--- a/src/Support/Str.lua
+++ b/src/Support/Str.lua
@@ -5,6 +5,24 @@ local Str = {}
     Str.__index = Str
 
     --[[
+    Replaces all occurrences of a substring in a string with another
+    substring.
+
+    This function does not support regular expressions. If regular
+    expressions are needed, please use Lua's string.gsub function. It was
+    created for the convenience of allowing quick replacements that also
+    accept characters like ".", "(", "[", etc, that would be interpreted as
+    regular expressions metacharacters.
+
+    @tparam string value
+    @tparam string find
+    @tparam string replace
+    ]]
+    function Str:replaceAll(value, find, replace)
+        return (value:gsub(find:gsub("[%(%)%.%+%-%*%?%[%]%^%$%%]", "%%%1"), replace))
+    end
+
+    --[[
     Splits a string in a table by breaking it where the separator is found.
 
     @tparam string value

--- a/src/stormwind-library.lua
+++ b/src/stormwind-library.lua
@@ -1,5 +1,7 @@
 -- Library version = '0.0.7'
 
+-- import src/Commands/CommandsHandler.lua
+
 -- import src/Core/Factory.lua
 
 -- import src/Facades/Target.lua

--- a/src/stormwind-library.lua
+++ b/src/stormwind-library.lua
@@ -1,8 +1,9 @@
 -- Library version = '0.0.7'
 
--- import src/Commands/CommandsHandler.lua
-
 -- import src/Core/Factory.lua
+
+-- import src/Commands/Command.lua
+-- import src/Commands/CommandsHandler.lua
 
 -- import src/Facades/Target.lua
 

--- a/src/stormwind-library.lua
+++ b/src/stormwind-library.lua
@@ -1,5 +1,9 @@
 -- Library version = '0.0.7'
 
+-- import src/Support/Arr.lua
+-- import src/Support/Str.lua
+
+-- import src/Core/AddonProperties.lua
 -- import src/Core/Factory.lua
 
 -- import src/Commands/Command.lua
@@ -8,6 +12,3 @@
 -- import src/Facades/Target.lua
 
 -- import src/Models/Macro.lua
-
--- import src/Support/Arr.lua
--- import src/Support/Str.lua

--- a/tests/Commands/CommandsHandlerTest.lua
+++ b/tests/Commands/CommandsHandlerTest.lua
@@ -10,7 +10,7 @@ TestCommandsHandler = {}
 
         handler:add(command)
 
-        lu.assertEquals('test-callback', handler.operations['test-operation'])
+        lu.assertEquals(command, handler.operations['test-operation'])
     end
 
     -- @covers StormwindLibrary.commands
@@ -41,6 +41,15 @@ TestCommandsHandler = {}
         handler:handle('test-operation arg1 arg2 arg3')
 
         lu.assertEquals({'arg1', 'arg2', 'arg3'}, invokedArgs)
+    end
+
+    --[[
+    @covers StormwindLibrary:handle()
+
+    This test just makes sure an invalid operation won't throw errors
+    ]]
+    function TestCommandsHandler:testHandleWithInvalidOperation()
+        __:new('CommandsHandler'):handle('invalid-operation')
     end
 
     -- @covers StormwindLibrary:parseArguments()

--- a/tests/Commands/CommandsHandlerTest.lua
+++ b/tests/Commands/CommandsHandlerTest.lua
@@ -13,6 +13,51 @@ TestCommandsHandler = {}
         lu.assertEquals(command, handler.operations['test-operation'])
     end
 
+    -- @covers StormwindLibrary:addHelpOperation()
+    function TestCommandsHandler:testAddHelpOperation()
+        local handler = __:new('CommandsHandler')
+
+        handler:addHelpOperation()
+
+        lu.assertNotNil(handler.operations['help'])
+    end
+
+    -- @covers StormwindLibrary:buildHelpContent()
+    function TestCommandsHandler:testBuildHelpContent()
+        local handler = __:new('CommandsHandler')
+
+        lu.assertEquals('', handler:buildHelpContent())
+
+        local commandA = __
+            :new('Command')
+            :setOperation('test-operation-a')
+            :setDescription('test-callback-a-description')
+
+        local commandB = __
+            :new('Command')
+            :setOperation('test-operation-b')
+            :setDescription('test-callback-b-description')
+
+        local commandC = __
+            :new('Command')
+            :setOperation('test-operation-c')
+
+        local helpCommand = __
+            :new('Command')
+            :setOperation('help')
+
+        handler:add(commandC)
+        handler:add(commandA)
+        handler:add(helpCommand)
+        handler:add(commandB)
+
+        lu.assertEquals(
+[[Available operations:
+test-operation-a - test-callback-a-description
+test-operation-b - test-callback-b-description
+test-operation-c]], handler:buildHelpContent())
+    end
+
     -- @covers StormwindLibrary.commands
     function TestCommandsHandler:testGetCommandsHandler()
         local handler = __.commands

--- a/tests/Commands/CommandsHandlerTest.lua
+++ b/tests/Commands/CommandsHandlerTest.lua
@@ -1,0 +1,8 @@
+TestCommandsHandler = {}
+    -- @covers StormwindLibrary.commands
+    function TestCommandsHandler:testGetCommandsHandler()
+        local handler = __.commands
+
+        lu.assertIsTable(handler)
+    end
+-- end of TestTarget

--- a/tests/Commands/CommandsHandlerTest.lua
+++ b/tests/Commands/CommandsHandlerTest.lua
@@ -1,8 +1,23 @@
 TestCommandsHandler = {}
+    -- @covers StormwindLibrary:add()
+    function TestCommandsHandler:testAdd()
+        local handler = __.commands
+
+        local command = __
+            :new('Command')
+            :setOperation('test-operation')
+            :setCallback('test-callback')
+
+        handler:add(command)
+
+        lu.assertEquals('test-callback', handler.operations['test-operation'])
+    end
+
     -- @covers StormwindLibrary.commands
     function TestCommandsHandler:testGetCommandsHandler()
         local handler = __.commands
 
         lu.assertIsTable(handler)
+        lu.assertIsTable(handler.operations)
     end
 -- end of TestTarget

--- a/tests/Commands/CommandsHandlerTest.lua
+++ b/tests/Commands/CommandsHandlerTest.lua
@@ -20,4 +20,22 @@ TestCommandsHandler = {}
         lu.assertIsTable(handler)
         lu.assertIsTable(handler.operations)
     end
+
+    -- @covers StormwindLibrary:parseArguments()
+    function TestCommandsHandler:testParseArguments()
+        local function execution(value, expectedOutput)
+            local output = __.commands:parseArguments(value)
+
+            lu.assertEquals(expectedOutput, output)
+        end
+
+        execution(nil, {})
+        execution('', {})
+        execution('    ', {})
+        execution('test', {'test'})
+        execution('test with multiple words', {'test', 'with', 'multiple', 'words'})
+        execution('test   with   multiple    spaces', {'test', 'with', 'multiple', 'spaces'})
+        execution('"test with" "multiple words in double quotes"', {'test with', 'multiple words in double quotes'})
+        execution("'test with' 'multiple words in quotes'", {'test with', 'multiple words in quotes'})
+    end
 -- end of TestTarget

--- a/tests/Commands/CommandsHandlerTest.lua
+++ b/tests/Commands/CommandsHandlerTest.lua
@@ -21,6 +21,28 @@ TestCommandsHandler = {}
         lu.assertIsTable(handler.operations)
     end
 
+    -- @covers StormwindLibrary:handle()
+    function TestCommandsHandler:testHandle()
+        local invokedArgs = nil
+
+        local function callback(arg1, arg2, arg3) invokedArgs = {arg1, arg2, arg3} end
+
+        local command = __
+            :new('Command')
+            :setOperation('test-operation')
+            :setCallback(callback)
+
+        local handler = __:new('CommandsHandler')
+
+        handler:add(command)
+
+        lu.assertIsNil(invokedArgs)
+
+        handler:handle('test-operation arg1 arg2 arg3')
+
+        lu.assertEquals({'arg1', 'arg2', 'arg3'}, invokedArgs)
+    end
+
     -- @covers StormwindLibrary:parseArguments()
     function TestCommandsHandler:testParseArguments()
         local function execution(value, expectedOutput)
@@ -37,5 +59,48 @@ TestCommandsHandler = {}
         execution('test   with   multiple    spaces', {'test', 'with', 'multiple', 'spaces'})
         execution('"test with" "multiple words in double quotes"', {'test with', 'multiple words in double quotes'})
         execution("'test with' 'multiple words in quotes'", {'test with', 'multiple words in quotes'})
+    end
+
+    -- @covers StormwindLibrary:parseOperationAndArguments()
+    function TestCommandsHandler:testParseOperationAndArguments()
+        local function execution(args, expectedOperation, expectedArguments)
+            local operation, arguments = __.commands:parseOperationAndArguments(args)
+
+            lu.assertEquals(expectedOperation, operation)
+            lu.assertEquals(expectedArguments, arguments)
+        end
+
+        execution(nil, nil, {})
+        execution({}, nil, {})
+        execution({'test'}, 'test', {})
+        execution({'test', 'with', 'multiple', 'args'}, 'test', {'with', 'multiple', 'args'})
+    end
+
+    -- @covers StormwindLibrary:register()
+    function TestCommandsHandler:testRegister()
+        local function execution(command, expectedGlobalSlashCommandIndex, expectedSlashCommand, expectedSlashCmdListIndex)
+            -- save the current data to restore them after the test
+            local currentCommand = __.addon.command
+            local currentSlashCmdList = SlashCmdList 
+
+            -- mocks the properties for this test
+            SlashCmdList = {}
+            __.addon.command = command
+
+            __.commands:register()
+
+            if expectedGlobalSlashCommandIndex then
+                lu.assertNotIsNil(__.arr:get(_G, expectedGlobalSlashCommandIndex))
+                lu.assertEquals(expectedSlashCommand, _G[expectedGlobalSlashCommandIndex])
+                lu.assertIsFunction(SlashCmdList[expectedSlashCmdListIndex])
+            end
+
+            -- restore the command after the test
+            __.addon.command = command
+            SlashCmdList = currentSlashCmdList
+        end
+
+        execution(nil, nil, nil, nil)
+        execution('test', 'SLASH_TEST1', '/test', 'TEST')
     end
 -- end of TestTarget

--- a/tests/Commands/CommandsTest.lua
+++ b/tests/Commands/CommandsTest.lua
@@ -1,5 +1,6 @@
 TestCommand = {}
     -- @covers Command:setCallback()
+    -- @covers Command:setDescription()
     -- @covers Command:setOperation()
     function TestCommand:testChainedSetters()
         local command = __:new('Command')
@@ -12,6 +13,21 @@ TestCommand = {}
         lu.assertEquals('test-callback', command.callback)
         lu.assertEquals('test-description', command.description)
         lu.assertEquals('test-operation', command.operation)
+    end
+
+    -- @covers Command:getHelpContent()
+    function TestCommand:testGetHelpContent()
+        local function execution(command, expectedOutput)
+            lu.assertEquals(expectedOutput, command:getHelpContent())
+        end
+
+        local emptyCommand = __:new('Command')
+        local commandWithoutDescription = __:new('Command'):setOperation('test-operation')
+        local completeCommand = __:new('Command'):setOperation('test-operation'):setDescription('test-description')
+
+        execution(emptyCommand, nil)
+        execution(commandWithoutDescription, 'test-operation')
+        execution(completeCommand, 'test-operation - test-description')
     end
 
     -- @covers Command:__construct()

--- a/tests/Commands/CommandsTest.lua
+++ b/tests/Commands/CommandsTest.lua
@@ -6,9 +6,11 @@ TestCommand = {}
         
         command
             :setCallback('test-callback')
+            :setDescription('test-description')
             :setOperation('test-operation')
 
         lu.assertEquals('test-callback', command.callback)
+        lu.assertEquals('test-description', command.description)
         lu.assertEquals('test-operation', command.operation)
     end
 

--- a/tests/Commands/CommandsTest.lua
+++ b/tests/Commands/CommandsTest.lua
@@ -1,4 +1,20 @@
 TestCommand = {}
+    -- @covers Command:setAction()    
+    -- @covers Command:setCallback()
+    -- @covers Command:setName()
+    function TestCommand:testChainedSetters()
+        local command = __:new('Command')
+        
+        command
+            :setName('test-name')
+            :setAction('test-action')
+            :setCallback('test-callback')
+
+        lu.assertEquals('test-name', command.name)
+        lu.assertEquals('test-action', command.action)
+        lu.assertEquals('test-callback', command.callback)
+    end
+
     -- @covers Command:__construct()
     function TestCommand:testInstantiate()
         local command = __:new('Command')

--- a/tests/Commands/CommandsTest.lua
+++ b/tests/Commands/CommandsTest.lua
@@ -1,0 +1,8 @@
+TestCommand = {}
+    -- @covers Command:__construct()
+    function TestCommand:testInstantiate()
+        local command = __:new('Command')
+
+        lu.assertNotIsNil(command)
+    end
+-- end of TestCommand

--- a/tests/Commands/CommandsTest.lua
+++ b/tests/Commands/CommandsTest.lua
@@ -1,18 +1,15 @@
 TestCommand = {}
-    -- @covers Command:setAction()    
     -- @covers Command:setCallback()
-    -- @covers Command:setName()
+    -- @covers Command:setOperation()
     function TestCommand:testChainedSetters()
         local command = __:new('Command')
         
         command
-            :setName('test-name')
-            :setAction('test-action')
             :setCallback('test-callback')
+            :setOperation('test-operation')
 
-        lu.assertEquals('test-name', command.name)
-        lu.assertEquals('test-action', command.action)
         lu.assertEquals('test-callback', command.callback)
+        lu.assertEquals('test-operation', command.operation)
     end
 
     -- @covers Command:__construct()

--- a/tests/Facades/TargetTest.lua
+++ b/tests/Facades/TargetTest.lua
@@ -1,5 +1,5 @@
 TestTarget = {}
-    -- @covers StormwindLibrary:getTarget()
+    -- @covers StormwindLibrary.target
     function TestTarget:testGetTargetFacade()
         local target = __.target
 

--- a/tests/Support/StrTest.lua
+++ b/tests/Support/StrTest.lua
@@ -1,6 +1,28 @@
 TestStr = {}
+    -- @covers Str:replaceAll()
+    function TestStr:testReplaceAll()
+        local function execution(value, find, replace, expectedOutput)
+            lu.assertEquals(expectedOutput, __.str:replaceAll(value, find, replace))
+        end
+
+        execution('', '', '', '')
+        execution('', 'a', 'b', '')
+        execution('a', 'a', 'b', 'b')
+        execution('aabb', 'a', 'b', 'bbbb')
+        execution('aa.bb', '.', '_', 'aa_bb')
+        execution('aa(bb)', '(', '-', 'aa-bb)')
+        execution('aa(bb)', ')', '-', 'aa(bb-')
+        execution('a word', 'word', 'phrase', 'a phrase')
+        execution('this is a test.', 'test.', 'result', 'this is a result')
+        execution('test[with square brackets', '[', ' ', 'test with square brackets')
+        execution('test]with square brackets', ']', ' ', 'test with square brackets')
+        execution('test\\with backslash', '\\', ' ', 'test with backslash')
+        execution('test with "double quotes"', '"', '', 'test with double quotes')
+        execution("test with 'quotes'", "'", '', 'test with quotes')
+    end
+
     -- @covers Str:split()
-    function TestStr:testCanSplit()
+    function TestStr:testSplit()
         local function execution(value, separator, expectedOutput)
             lu.assertEquals(expectedOutput, __.str:split(value, separator))
         end

--- a/tests/Support/StrTest.lua
+++ b/tests/Support/StrTest.lua
@@ -8,5 +8,6 @@ TestStr = {}
         execution('', '.', {})
         execution('test', '.', {'test'})
         execution('test-a.test-b.test-c', '.', {'test-a', 'test-b', 'test-c'})
+        execution('test-a test-b test-c', ' ', {'test-a', 'test-b', 'test-c'})
     end
 -- end of TestStr

--- a/tests/unit.lua
+++ b/tests/unit.lua
@@ -1,8 +1,10 @@
 lu = require('luaunit')
 
 dofile('./dist/stormwind-library.lua')
-function newLibrary() return StormwindLibrary_v0_0_6.new() end
+function newLibrary() return StormwindLibrary_v0_0_7.new() end
     __ = newLibrary()
+
+dofile('./tests/Commands/CommandsHandlerTest.lua')
 
 dofile('./tests/Core/FactoryTest.lua')
 

--- a/tests/unit.lua
+++ b/tests/unit.lua
@@ -4,6 +4,7 @@ dofile('./dist/stormwind-library.lua')
 function newLibrary() return StormwindLibrary_v0_0_7.new() end
     __ = newLibrary()
 
+dofile('./tests/Commands/CommandsTest.lua')
 dofile('./tests/Commands/CommandsHandlerTest.lua')
 
 dofile('./tests/Core/FactoryTest.lua')


### PR DESCRIPTION
# Pending items

- [x] Add documentation
    - [x] Remember the docs for addon properties inside the library
- [x] Add test coverage for everything added in this PR
- [x] Allow parameters after operation
    - ❌ Option to select whether the last parameters should be split by ` ` or not
        - ❌ If so, split
        - ❌ Otherwise, pass the whole string
- [x] Add the command's description
- ❌ Allow a default operation (in case the addon registers a single command with no args)
- [x] Add a default **help** operation that can be override